### PR TITLE
feat(keenetic): VPN-клиент под роутеры Keenetic (dual-arch mipsel+aarch64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - 'qeli-android/**'
       - 'qeli-win/**'
       - 'qeli-mac/**'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 defaults:
@@ -93,6 +94,57 @@ jobs:
       - name: Build QeliMac (Release)
         working-directory: qeli-mac
         run: dotnet build QeliMac/QeliMac.csproj -c Release
+
+  # Soft-gate: клиент для роутера (Keenetic) кросс-компилируется под обе арки —
+  # aarch64 (stable) и mipsel (tier-3: nightly + -Zbuild-std). Линкер/cc — zig через
+  # cargo-zigbuild (OpenWrt SDK не нужен). Только сборка; рантайм проверяется на устройстве.
+  # Арк-специфичные TUNSETIFF (тип/значение) и float-ABI mipsel видны ТОЛЬКО здесь, не на
+  # x86-гейте build-test выше — этот job ловит молчаливую поломку кросс-сборки.
+  keenetic-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            target: aarch64-unknown-linux-musl
+            toolchain: stable
+          - arch: mipsel
+            target: mipsel-unknown-linux-musl
+            toolchain: nightly
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.13.0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Per-arch toolchain bits
+        run: |
+          if [ "${{ matrix.arch }}" = "aarch64" ]; then
+            rustup target add aarch64-unknown-linux-musl
+          else
+            rustup component add rust-src
+          fi
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: qeli
+      - name: Install cargo-zigbuild
+        run: cargo install cargo-zigbuild --locked
+      - name: Cross-build qeli-client (${{ matrix.arch }})
+        run: |
+          if [ "${{ matrix.arch }}" = "mipsel" ]; then
+            RUSTFLAGS='-C link-arg=-msoft-float' cargo zigbuild -Z build-std=std,panic_abort \
+              --release --bin qeli-client --no-default-features --features client-bin \
+              --target ${{ matrix.target }}
+          else
+            cargo zigbuild \
+              --release --bin qeli-client --no-default-features --features client-bin \
+              --target ${{ matrix.target }}
+          fi
+      - name: Artifact info
+        run: file target/${{ matrix.target }}/release/qeli-client
 
   # Advisory: surface known RustSec advisories in the dependency tree. Non-gating
   # for now (a transient upstream advisory shouldn't block a merge); promote to a

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ release/dist/
 release/*.apk
 release/*.deb
 release/qeli-linux-amd64
+# Keenetic cross-built binaries (шаблоны деплоя в release/keenetic/ — трекаем, бинари — нет)
+release/keenetic/qeli-client-*
 
 # ── Python caches ──
 __pycache__/

--- a/docs/KEENETIC-DEPLOY.md
+++ b/docs/KEENETIC-DEPLOY.md
@@ -1,0 +1,197 @@
+# qeli-client на Keenetic — пошаговый деплой
+
+Развёртывание qeli-VPN-клиента на роутере Keenetic (Entware) как шлюза для всего LAN.
+Архитектура и обоснование порта — [KEENETIC-PORT.md](KEENETIC-PORT.md). Файлы бандла —
+в `release/keenetic/`.
+
+> ⚠️ Скрипты бандла — **шаблоны**, на живом Кинетике не тестировались. Команды ниже
+> универсальны; имена интерфейсов и взаимодействие с firewall KeeneticOS зависят от
+> модели и версии прошивки — проверяй по месту.
+
+---
+
+## Предусловия
+
+- На роутере установлен **Entware** (пакетный менеджер `opkg`, каталог `/opt`).
+- Включён **SSH** и есть доступ к шеллу роутера.
+- Включён компонент **VPN** в KeeneticOS (любой из WireGuard/OpenVPN/IPsec) — он
+  обеспечивает наличие `/dev/net/tun`. Добавляется в веб-морде: *Управление → Общие
+  настройки → Изменить набор компонентов*.
+- Есть рабочий **сервер qeli** с профилем и заведённым для роутера клиентом.
+
+---
+
+## Шаг 0. Разведка роутера (по SSH на роутер)
+
+```sh
+opkg print-architecture | grep -E 'aarch64|mipsel|mips'   # арка пакетов
+cat /proc/cpuinfo | grep -E 'cpu model|FPU|system type'   # CPU/FPU
+ls -l /dev/net/tun                                         # должен существовать
+df -h /opt                                                 # место (нужно ~5-10 МБ)
+```
+
+- `mipsel-…` → бинарь `qeli-client-mipsel` (MT7621/7628 и т.п.).
+- `aarch64-…` → бинарь `qeli-client-aarch64` (новые ARM-модели).
+- Нет `/dev/net/tun` → вернись к предусловиям и включи компонент VPN.
+
+---
+
+## Шаг 1. Собрать бинари (на деве/лабе, не на роутере)
+
+```sh
+python scripts/build_keenetic.py
+# → release/keenetic/qeli-client-aarch64   (static ARM aarch64)
+# → release/keenetic/qeli-client-mipsel    (static-pie MIPS32r2)
+```
+
+Можно собрать только нужную арку: `python scripts/build_keenetic.py mipsel`.
+
+---
+
+## Шаг 2. Получить креды клиента от сервера (на сервере qeli)
+
+```sh
+# Завести клиента и сразу получить qeli://-ссылку (и пароль — печатается ОДИН раз):
+qeli add-client router1 --link --host <публичный_адрес_сервера>
+
+# Публичный ключ сервера для пиннинга (анти-MITM):
+qeli show-identity
+```
+
+Из ссылки/вывода понадобятся: `server` (host:port), `proto` (tcp/udp), `user`, `pass`,
+`key` (server pubkey), `mode` (fake-tls/obfs/plain/…), `sni`.
+
+---
+
+## Шаг 3. Скопировать бандл на роутер (с дева)
+
+```sh
+scp -r release/keenetic <user>@<router-ip>:/opt/tmp/keenetic
+# <user> — аккаунт роутера с доступом к /opt (обычно admin/root). Альтернатива — USB.
+```
+
+---
+
+## Шаг 4. Установка (на роутере)
+
+```sh
+cd /opt/tmp/keenetic
+sh install-keenetic.sh
+```
+
+Скрипт: определит арку → положит нужный бинарь в `/opt/bin/qeli-client`; поставит
+`ip-full` и `iptables` (busybox-`ip` Кинетика урезан — нет `tuntap`); проверит
+`/dev/net/tun`; разложит `S99qeli` и болванку конфига.
+
+---
+
+## Шаг 5. Заполнить конфиг (на роутере)
+
+```sh
+vi /opt/etc/qeli/client.conf
+```
+
+Подставь значения из Шага 2. Для роутера-шлюза важны два ключа:
+
+```ini
+[qeli]
+server = vpn.example.com:443
+proto  = tcp
+user   = router1
+pass   = <пароль>
+key    = <server pubkey из show-identity>
+mode   = fake-tls           # MIPS: fake-tls | obfs | plain (ChaCha20). reality-tls
+sni    = www.cloudflare.com #       на mipsel очень медленный — только для ARM
+gateway = true              # весь трафик LAN в туннель (full-tunnel)
+dns     = off               # НЕ трогать резолвер роутера (им владеет прошивка)
+
+[logging]
+level = info
+file  = /opt/var/log/qeli-client.log
+```
+
+---
+
+## Шаг 6. Проверить интерфейсы для NAT (на роутере)
+
+```sh
+ip a            # найди LAN-бридж (обычно br0) и убедись, что tun будет vpn0
+```
+
+Если LAN-бридж не `br0` или tun не `vpn0` — поправь переменные в начале `S99qeli`:
+
+```sh
+vi /opt/etc/init.d/S99qeli      # TUN=…, LAN_IF=…, GATEWAY=yes
+```
+
+---
+
+## Шаг 7. Запуск
+
+```sh
+/opt/etc/init.d/S99qeli start
+tail -f /opt/var/log/qeli-client.log
+```
+
+Жди строку `Auth OK, assigned IP: 10.x.x.x` — это успешное подключение к серверу.
+Init-скрипт с префиксом `S` Entware запускает **автоматически при загрузке роутера**.
+
+---
+
+## Шаг 8. Проверить туннель
+
+На роутере:
+
+```sh
+ip a show vpn0                                  # у tun есть адрес 10.x.x.x
+ip route | grep -E 'default|vpn0'               # при gateway=true — default via vpn0
+iptables -t nat -L POSTROUTING -n | grep MASQUERADE   # NAT на vpn0 стоит
+curl -s https://ifconfig.me ; echo             # внешний IP = адрес VPN-сервера
+```
+
+С любого LAN-клиента (телефон/ПК за роутером):
+
+```sh
+# внешний IP должен стать адресом VPN-сервера; DNS и сайты открываются
+curl -s https://ifconfig.me ; echo
+```
+
+---
+
+## Селективный режим (только часть трафика через VPN)
+
+Вместо full-tunnel (`gateway=true`) можно заворачивать лишь нужные адреса:
+`gateway = false` в конфиге + `ipset` + `iptables` + DNS-оверрайды на dnsmasq
+роутера (подход как у проектов `kvas` / `antizapret` для Keenetic). Это гибче и не
+режет скорость на не-VPN трафике, но настройка ручная и вне этого бандла.
+
+---
+
+## Диагностика
+
+| Симптом | Причина / что делать |
+|---|---|
+| `нет /dev/net/tun` при старте | Включить компонент VPN в KeeneticOS (предусловия) |
+| `ip: ... tuntap` не работает | `opkg install ip-full` (busybox-`ip` урезан) |
+| Нет `Auth OK`, `SERVER KEY MISMATCH` | Неверный `key` — сверь с `qeli show-identity` на сервере |
+| Нет `Auth OK`, `auth failed` | Неверные `user`/`pass`, либо `mode`/`sni` не совпадают с профилем сервера |
+| LAN без интернета, роутер с интернетом | Проверь `ip_forward`, `MASQUERADE`, правильное имя `LAN_IF` в `S99qeli` |
+| После ребута сервер видит «новое устройство» | `QELI_DEVICE_ID_FILE` должен быть на `/opt` (в `S99qeli` уже так; `/var` — tmpfs) |
+| Очень медленно (mipsel) | Потолок CPU без AES-NI; ставь `mode = obfs`/`plain`, не `reality-tls` |
+| Туннель рвётся | Авто-reconnect включён; смотри `/opt/var/log/qeli-client.log` |
+
+---
+
+## Обновление / удаление
+
+```sh
+# обновить бинарь: останови, замени, запусти
+/opt/etc/init.d/S99qeli stop
+install -m755 qeli-client-<арка> /opt/bin/qeli-client
+/opt/etc/init.d/S99qeli start
+
+# удалить полностью
+/opt/etc/init.d/S99qeli stop
+rm -f /opt/etc/init.d/S99qeli /opt/bin/qeli-client
+rm -rf /opt/etc/qeli /opt/var/log/qeli-client.log
+```

--- a/docs/KEENETIC-PORT.md
+++ b/docs/KEENETIC-PORT.md
@@ -1,0 +1,214 @@
+# Порт qeli-клиента на Keenetic (dual-arch: mipsel + aarch64)
+
+Статус: **Фаза 1 в работе** (код-скелет применён, ждёт лаб-сборки). Цель — гонять
+существующий Linux-клиент `qeli` на роутерах Keenetic под Entware, **сразу под обе
+арки** модельного ряда: MIPS (mipsel) и ARM (aarch64). Без написания нового
+нативного клиента — переиспользуем демон.
+
+## 1. Вывод по осуществимости
+
+Keenetic — это Linux. Полноценный `qeli client` уже Linux-only (TUN через
+`/dev/net/tun` + `ioctl(TUNSETIFF)`), так что на роутер ставится тот же демон,
+кросс-собранный под CPU роутера.
+
+Единственный жёсткий блокер — **`ring`** (через `rustls`): у него нет MIPS-бэкенда.
+Но `ring`/`rustls`/`rcgen` используются **только на серверной стороне**
+(`protocol/realtls/server.rs`, `server/mod.rs`, `server/reality.rs`) плюс в
+тестах/доках. Клиентский путь, включая `reality-tls`, **рукописный на RustCrypto**
+(`realtls/{client,stream,sansio,keyschedule,record,clienthello}.rs`) — чистый Rust,
+портируется на любую арку. Значит **client-only сборка без `ring` собирается** после
+фич-рефактора (ниже), одинаково под mipsel и aarch64.
+
+## 2. Целевая матрица
+
+| Target | Покрывает | Класс Rust | Крипто на железе |
+|---|---|---|---|
+| `aarch64-unknown-linux-musl` | новые WiFi6 (Cortex-A53: Hopper, Peak/Filogic MT7981) | tier-1/2, std из rustup | ARMv8 crypto-ext → AES-GCM быстрый, `reality-tls` ок |
+| `mipsel-unknown-linux-musl` | основной парк (MT7621/MT7628: Giga/Ultra/Viva/...) | **tier-3**, нужен `-Zbuild-std` | софт ChaCha20 → `obfs`/`fake-tls`/`plain` |
+| *(опц.)* `mips-unknown-linux-musl` (BE) | редкие модели на Realtek | tier-3 | как mipsel |
+
+Оба основных таргета — **статический musl** (один бинарь в `/opt/bin`). Big-endian
+по умолчанию НЕ собираем.
+
+> Перед фиксацией тулчейнов снять с устройств `opkg print-architecture` (точная
+> ABI-строка, особенно mipsel: o32/float) и `cat /proc/cpuinfo` (FPU/crypto-ext).
+
+## 3. Единый код под обе арки (Фаза 1)
+
+Принцип: **архитектурно-специфичного Rust-кода ноль**. Разница уходит в (а) фичи
+Cargo и (б) тулчейн/рантайм. Идентичный по поведению бинарь под любой target.
+
+### 3.1 Фич-флаги (Cargo.toml)
+
+`rustls/tokio-rustls/rcgen/axum/tower/qrcode` → `optional = true`, включаются только
+фичей `server`. Введены:
+
+```toml
+[features]
+default    = ["server", "client"]   # обычная серверная сборка — как раньше
+server     = ["dep:rustls", "dep:tokio-rustls", "dep:rcgen", "dep:axum", "dep:tower", "dep:qrcode"]
+client     = []
+# Отдельный standalone-бинарь клиента (роутеры/Keenetic). ВЫКЛ по умолчанию,
+# чтобы серверные/CI/FFI-сборки оставались байт-идентичными прежним.
+client-bin = ["client"]
+```
+
+`default` сохраняет `server`+`client` → `cargo build` без флагов компилирует ровно
+то же, что и до правок (server + web + realtls::server + FFI-cdylib для
+Android/Win/Mac не затронуты).
+
+### 3.2 Гейтинг модулей
+
+- `lib.rs`: `client`/`tun` → `feature="client"`; `server`/`web`/`transport` →
+  `feature="server"` (плюс существующий `target_os="linux"`).
+- `protocol/realtls/mod.rs`: `pub mod server` → `#[cfg(feature="server")]`.
+  Клиентские подмодули (`client/stream/sansio/keyschedule/record/clienthello/ffi`)
+  остаются всегда (нужны и Linux-клиенту, и FFI win/mac). Ссылки на `realtls::server`
+  вне server-модулей есть только в `#[cfg(test)]` — сборка client-only их не
+  компилирует, а `cargo test` идёт с дефолтными фичами (server вкл).
+
+### 3.3 portable-atomic (нужен только 32-бит mipsel)
+
+На 32-бит mipsel нет 64-битных атомиков (`target_has_atomic="64"` = false) →
+`std::sync::atomic::AtomicU64` отсутствует, и код без правок **не компилируется**.
+`AtomicU64` в проде используется только в `client/mod.rs` (счётчики статы/`last_rx`;
+в `server/{handler,udp_handler}.rs` — но это server-only, в client-сборку не входит).
+
+Решение: зависимость `portable-atomic = "1"` и в `client/mod.rs`
+`use portable_atomic::AtomicU64;` вместо std. На aarch64/x86_64 маппится на нативную
+инструкцию (цена ноль), на mipsel — lock-fallback. Один путь кода для обеих арок.
+`tokio` свои внутренние `AtomicU64` уже шими́т сам (`loom/std/atomic_u64.rs`).
+
+### 3.4 Точка входа
+
+Новый бинарь `src/client_main.rs` (только подкоманда client), `required-features
+= ["client-bin"]`. Существующий `main.rs` **не трогаем**: бинарь `qeli`
+помечается `required-features = ["server","client"]`, поэтому client-only сборка его
+пропускает. Так default-сборка никогда не компилирует новый файл — нулевой риск для
+рабочих сборок.
+
+Команда Keenetic-сборки:
+```sh
+cargo build --release --bin qeli-client \
+  --no-default-features --features client-bin --target <TARGET>
+```
+`--no-default-features` гасит `server` → `rustls/ring/axum/...` не компилируются.
+
+## 4. Тулчейны (на лабе .10, рядом с кросс-сборками win/android/mac)
+
+### aarch64 (лёгкая дорожка)
+```sh
+rustup target add aarch64-unknown-linux-musl
+# линкер: aarch64-linux-musl-gcc (musl.cc toolchain) или установленный musl-cross
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+cargo build --release --bin qeli-client --no-default-features --features client-bin \
+  --target aarch64-unknown-linux-musl
+```
+std готов (tier-1/2), stable достаточно. Статический бинарь.
+
+### mipsel (тяжёлая дорожка, tier-3)
+```sh
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+# линкер из OpenWrt SDK под арку роутера (ABI должен совпасть с opkg print-architecture):
+#   mipsel-openwrt-linux-musl-gcc
+CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-musl-gcc \
+cargo +nightly build --release --bin qeli-client \
+  -Z build-std=std,panic_abort \
+  --no-default-features --features client-bin \
+  --target mipsel-unknown-linux-musl
+```
+Критично: **ABI/float совпадает** с Entware-фидом роутера; **полностью статически**
+(musl), чтобы не зависеть от libc устройства. Подобрать OpenWrt SDK под точную версию.
+
+### Один скрипт + CI
+- `scripts/build_keenetic.py` (по образцу существующих paramiko-кросс-скриптов) гонит
+  **оба** таргета за прогон, strip, кладёт `release/qeli-keenetic-{aarch64,mipsel}`.
+- В `ci.yml` добавить обе цели в build-матрицу клиентов (гейт, чтобы клиент-сборка
+  под обе арки не отвалилась незаметно).
+
+## 5. Рантайм на роутере (одинаково для обеих арок)
+
+1. **Entware** установлен (opkg, `/opt`). Бинарь → `/opt/bin/qeli-client`.
+2. `opkg install ip-full iptables` — клиент шеллит в `ip addr/route/link/tuntap`
+   (`tun/iface.rs`, `client/route.rs`); busybox-`ip` Keenetic'а урезан (нет `tuntap`).
+3. **`/dev/net/tun`**: должен быть (включить VPN-компонент KeeneticOS — WireGuard/
+   OpenVPN — он тянет tun-модуль). Проверка: `ls -l /dev/net/tun`.
+4. Конфиг `/opt/etc/qeli/client.conf` (секция `[qeli]`), импорт из `qeli://`-ссылки.
+5. **device-id на персистентный путь**: по умолчанию `/var/lib/qeli/device-id`, на
+   роутере `/var` часто tmpfs (теряется при ребуте → сервер каждый раз видит «новое
+   устройство», тратит слот). В init-скрипте задать
+   `QELI_DEVICE_ID_FILE=/opt/etc/qeli/device-id` (env-override уже есть в коде).
+6. **DNS — не трогать resolv.conf роутера**: `dns.mode = off`/`manual` в конфиге
+   (`client/dns.rs::setup_dns_for_interface` делает early-return при `mode != tunnel`).
+   DNS LAN-клиентов — через штатный dnsmasq/ndnsproxy Keenetic.
+7. Автозапуск: `/opt/etc/init.d/S99qeli` (start/stop), от root. Авто-reconnect и
+   устойчивость к смене IP/линка в клиенте уже есть.
+
+## 6. Режим шлюза — роутер как VPN для всего LAN
+
+Клиент спроектирован как endpoint и **NAT сам не ставит**. Для заворота LAN:
+
+```sh
+echo 1 > /proc/sys/net/ipv4/ip_forward
+iptables -t nat -A POSTROUTING -o vpn0 -j MASQUERADE
+iptables -A FORWARD -i br0 -o vpn0 -j ACCEPT
+iptables -A FORWARD -i vpn0 -o br0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+```
+
+Два под-режима маршрутизации:
+- **Full-tunnel**: весь трафик LAN в туннель. Клиент уже умеет ставить default route
+  через tun + bypass-маршрут до сервера (`client/route.rs`, `add_default_gateway`/
+  `full-tunnel`). Включается в `[routing]`.
+- **Селективный (по доменам/IP)**: `ipset` + `iptables` + dnsmasq-роутера (паттерн как
+  у kvas/antizapret на Keenetic). Гибче и дружелюбнее к скорости.
+
+> ⚠️ Самая капризная часть: взаимодействие с собственным firewall/NAT KeeneticOS
+> зависит от модели и версии прошивки — проверять на живом устройстве.
+
+## 7. Производительность и выбор wire-режима
+
+| | mipsel (MT7621 ~880МГц, без AES-NI) | aarch64 (A53 + crypto-ext) |
+|---|---|---|
+| Рекоменд. режим | `obfs`/`fake-tls`/`plain` (ChaCha20) | можно `reality-tls` |
+| Ожидаемый потолок | десятки Мбит | сотни Мбит |
+| `reality-tls` | очень медленно (двойной AEAD, <~20 Мбит) | приемлемо |
+
+Выбор режима — это конфиг на устройстве, **не разный бинарь**.
+
+## 8. Риски
+
+- **mipsel-сборка** — основной техриск (tier-3 + `-Zbuild-std` + ABI-match + atomics).
+  На aarch64 этого нет.
+- **Перф на MIPS** — потолок десятки Мбит (софт-крипто). Для канала до ~50–100 Мбит
+  ок, для гигабита нет.
+- **Интеграция с NAT/firewall KeeneticOS** — непредсказуема, зависит от модели/прошивки.
+- **Нет нативной интеграции в веб-морду KeeneticOS** — это сторонний Entware-демон
+  (SSH/init-скрипт). Полноценный KeeneticOS-компонент требует SDK Keenetic — вне реализма.
+
+## 9. Чек-лист
+
+**Фаза 1 — код-скелет + лаб-верификация ✅ PASS (2026-06-11):**
+- [x] Cargo.toml: server-депы → optional; фичи `server`/`client`/`client-bin`
+- [x] lib.rs: модули под фичи
+- [x] protocol/realtls/mod.rs: `server` под `feature="server"`
+- [x] client/mod.rs: `AtomicU64` → `portable_atomic`
+- [x] src/client_main.rs: standalone-клиент
+- [x] **верификация на .10** (`scripts/keenetic_verify.py`): дефолтная `cargo build --release`
+  = OK (не сломана); `cargo build --bin qeli-client --no-default-features --features
+  client-bin` = OK (без rustls/axum/rcgen в графе); client-bin `clippy -D warnings` = OK;
+  `cargo tree -i ring` → «did not match any packages» (**ring отсутствует**); бинарь = ELF x86-64.
+
+**Фаза 2 — тулчейны и кросс-сборка:**
+- [ ] aarch64-musl: target + линкер + статик-сборка
+- [ ] mipsel-musl: nightly + build-std + OpenWrt SDK (ABI по `opkg print-architecture`)
+- [ ] `scripts/build_keenetic.py` (оба таргета) + CI-матрица
+
+**Фаза 3 — рантайн/деплой:**
+- [ ] `install-keenetic.sh` (детект арки → нужный бинарь), `ip-full`/`iptables`, tun-проба
+- [ ] init `/opt/etc/init.d/S99qeli` + `QELI_DEVICE_ID_FILE` персистентный
+- [ ] клиент-конфиг (`dns.mode=off`), NAT/forward, режим шлюза (full/селективный)
+
+**Фаза 4 — e2e и замеры:**
+- [ ] туннель против прод-сервера, ping/speedtest с LAN-клиента (mips + arm)
+- [ ] подбор wire-режима под железо

--- a/docs/KEENETIC-PORT.md
+++ b/docs/KEENETIC-PORT.md
@@ -94,38 +94,40 @@ cargo build --release --bin qeli-client \
 ```
 `--no-default-features` гасит `server` → `rustls/ring/axum/...` не компилируются.
 
-## 4. Тулчейны (на лабе .10, рядом с кросс-сборками win/android/mac)
+## 4. Тулчейны (на лабе .10) — обе арки через zig ✅
 
-### aarch64 (лёгкая дорожка)
+Линкер/cc для обеих арок — **zig 0.13** (уже стоит на .10) через `cargo-zigbuild`.
+OpenWrt SDK НЕ понадобился. Канонический скрипт — `scripts/build_keenetic.py`
+(idempotent-сетап nightly+rust-src+aarch64-target+cargo-zigbuild, сборка обеих арок,
+strip, пулл в `release/keenetic/`). Разведка тулчейна — `scripts/keenetic_toolchain_probe.py`.
+
+### aarch64 (stable, std из rustup) → ~2.3 МБ, static ARM aarch64
 ```sh
 rustup target add aarch64-unknown-linux-musl
-# линкер: aarch64-linux-musl-gcc (musl.cc toolchain) или установленный musl-cross
-CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-cargo build --release --bin qeli-client --no-default-features --features client-bin \
-  --target aarch64-unknown-linux-musl
+cargo zigbuild --release --bin qeli-client \
+  --no-default-features --features client-bin --target aarch64-unknown-linux-musl
 ```
-std готов (tier-1/2), stable достаточно. Статический бинарь.
 
-### mipsel (тяжёлая дорожка, tier-3)
+### mipsel (tier-3: nightly + build-std) → ~3.3 МБ, static-pie MIPS32r2 LE
 ```sh
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-# линкер из OpenWrt SDK под арку роутера (ABI должен совпасть с opkg print-architecture):
-#   mipsel-openwrt-linux-musl-gcc
-CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-openwrt-linux-musl-gcc \
-cargo +nightly build --release --bin qeli-client \
-  -Z build-std=std,panic_abort \
-  --no-default-features --features client-bin \
-  --target mipsel-unknown-linux-musl
+rustup toolchain install nightly -c rust-src
+# Rust компилит mipsel в soft-float, а zig линкует mips как fpxx → конфликт float-ABI.
+# Принуждаем линковку к soft-float (бинарь не трогает FPU — идёт на любом mips):
+RUSTFLAGS='-C link-arg=-msoft-float' cargo +nightly zigbuild \
+  -Z build-std=std,panic_abort --release --bin qeli-client \
+  --no-default-features --features client-bin --target mipsel-unknown-linux-musl
 ```
-Критично: **ABI/float совпадает** с Entware-фидом роутера; **полностью статически**
-(musl), чтобы не зависеть от libc устройства. Подобрать OpenWrt SDK под точную версию.
 
-### Один скрипт + CI
-- `scripts/build_keenetic.py` (по образцу существующих paramiko-кросс-скриптов) гонит
-  **оба** таргета за прогон, strip, кладёт `release/qeli-keenetic-{aarch64,mipsel}`.
-- В `ci.yml` добавить обе цели в build-матрицу клиентов (гейт, чтобы клиент-сборка
-  под обе арки не отвалилась незаметно).
+### Gotchas, всплывшие при кросс-сборке (оба арк-специфичны — видны ТОЛЬКО тут, не на x86)
+- **TUNSETIFF** (`tun/iface.rs`): тип запроса `ioctl` — `c_ulong` на glibc, но `c_int`
+  на musl (кастуем `as _`); на MIPS другая кодировка `_IOW` → значение `0x800454ca`,
+  а не `0x400454ca` (выбор через `cfg(target_arch="mips")`). Иначе ioctl упал бы в
+  рантайме на живом Кинетике, хотя на x86 всё «зелено».
+- **float-ABI mipsel**: `-msoft-float` на линковке (см. выше).
+
+### CI
+- В `ci.yml` добавить обе цели в build-матрицу клиентов (гейт, чтобы кросс-сборка под
+  обе арки не отвалилась незаметно).
 
 ## 5. Рантайм на роутере (одинаково для обеих арок)
 
@@ -199,16 +201,24 @@ iptables -A FORWARD -i vpn0 -o br0 -m state --state RELATED,ESTABLISHED -j ACCEP
   client-bin` = OK (без rustls/axum/rcgen в графе); client-bin `clippy -D warnings` = OK;
   `cargo tree -i ring` → «did not match any packages» (**ring отсутствует**); бинарь = ELF x86-64.
 
-**Фаза 2 — тулчейны и кросс-сборка:**
-- [ ] aarch64-musl: target + линкер + статик-сборка
-- [ ] mipsel-musl: nightly + build-std + OpenWrt SDK (ABI по `opkg print-architecture`)
-- [ ] `scripts/build_keenetic.py` (оба таргета) + CI-матрица
+**Фаза 1.5 — config-ключи для роутера ✅ (2026-06-11):**
+- [x] `[qeli]` парсер: `gateway=true` (→ full-tunnel) и `dns=off` (→ не трогать резолвер
+  роутера) + эмит в `to_ini_string` + тест (`config/client.rs`); в qeli://-ссылку НЕ входят.
 
-**Фаза 3 — рантайн/деплой:**
-- [ ] `install-keenetic.sh` (детект арки → нужный бинарь), `ip-full`/`iptables`, tun-проба
-- [ ] init `/opt/etc/init.d/S99qeli` + `QELI_DEVICE_ID_FILE` персистентный
-- [ ] клиент-конфиг (`dns.mode=off`), NAT/forward, режим шлюза (full/селективный)
+**Фаза 2 — тулчейны и кросс-сборка ✅ PASS (2026-06-11):**
+- [x] aarch64-musl: `rustup target add` + `cargo zigbuild` → static ARM aarch64, 2.3 МБ
+- [x] mipsel-musl: nightly + `-Zbuild-std` + zig + `-msoft-float` → static-pie MIPS32r2, 3.3 МБ
+- [x] `scripts/build_keenetic.py` (обе арки, idempotent-сетап, пулл в `release/keenetic/`)
+- [x] арк-баги исправлены: TUNSETIFF (тип+значение per-arch), float-ABI (soft-float)
+- [ ] CI-матрица (обе цели в `ci.yml`)
 
-**Фаза 4 — e2e и замеры:**
+**Фаза 3 — рантайн/деплой ✅ шаблоны готовы (2026-06-11), нужна проверка на устройстве:**
+- [x] `release/keenetic/install-keenetic.sh` (детект арки → бинарь, `ip-full`/`iptables`, tun-проба)
+- [x] `release/keenetic/S99qeli` (Entware init + NAT/forward для шлюза + `QELI_DEVICE_ID_FILE`)
+- [x] `release/keenetic/client.conf.example` (`gateway`/`dns`) + `README.md`
+- [ ] **проверка на живом Кинетике** (нет устройства): арку, `/dev/net/tun`, имена интерфейсов,
+  взаимодействие с firewall/NAT KeeneticOS
+
+**Фаза 4 — e2e и замеры (нужно устройство):**
 - [ ] туннель против прод-сервера, ping/speedtest с LAN-клиента (mips + arm)
 - [ ] подбор wire-режима под железо

--- a/docs/KEENETIC-PORT.md
+++ b/docs/KEENETIC-PORT.md
@@ -131,6 +131,9 @@ RUSTFLAGS='-C link-arg=-msoft-float' cargo +nightly zigbuild \
 
 ## 5. Рантайм на роутере (одинаково для обеих арок)
 
+📖 **Пошаговый деплой с командами и проверкой туннеля — [KEENETIC-DEPLOY.md](KEENETIC-DEPLOY.md).**
+Ниже — обзор, полный гайд там.
+
 1. **Entware** установлен (opkg, `/opt`). Бинарь → `/opt/bin/qeli-client`.
 2. `opkg install ip-full iptables` — клиент шеллит в `ip addr/route/link/tuntap`
    (`tun/iface.rs`, `client/route.rs`); busybox-`ip` Keenetic'а урезан (нет `tuntap`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,7 @@ sudo /usr/bin/qeli client --config /etc/qeli/client.conf
 - **Сравнение с WireGuard/OpenVPN/V2Ray**: [COMPARISON.md](COMPARISON.md)
 - **План развития**: [ROADMAP.md](ROADMAP.md)
 - **План рефакторинга (устранение дублей кода)**: [REFACTOR-PLAN.md](REFACTOR-PLAN.md)
+- **Клиент на роутеры Keenetic (dual-arch mipsel+aarch64)**: [KEENETIC-PORT.md](KEENETIC-PORT.md) · пошаговый деплой: [KEENETIC-DEPLOY.md](KEENETIC-DEPLOY.md)
 
 ## Статус
 

--- a/qeli/Cargo.toml
+++ b/qeli/Cargo.toml
@@ -11,6 +11,32 @@ path = "src/lib.rs"
 # rlib for the binary/tests; cdylib/staticlib for the realtls FFI on Android/Windows.
 crate-type = ["rlib", "cdylib", "staticlib"]
 
+# Full daemon (server + web + realtls termination + CLI). The default; what the
+# server, CI, and the Android/Win/Mac FFI cdylib have always built.
+[[bin]]
+name = "qeli"
+path = "src/main.rs"
+required-features = ["server", "client"]
+
+# Standalone client binary for routers (Keenetic / Entware). Built ONLY under the
+# off-by-default `client-bin` feature, so normal builds never compile it — keeping
+# server/CI/FFI builds byte-identical to before. See docs/KEENETIC-PORT.md.
+# NB: lives at src/client_main.rs (NOT src/bin/) because .gitignore's `**/bin/`
+# would otherwise exclude it from git/CI.
+[[bin]]
+name = "qeli-client"
+path = "src/client_main.rs"
+required-features = ["client-bin"]
+
+[features]
+default = ["server", "client"]
+# Server side pulls the only MIPS-incompatible deps (rustls/ring via rcgen) plus
+# the web stack. A client-only build (`--no-default-features --features client-bin`)
+# excludes all of these and cross-compiles to mipsel/aarch64.
+server = ["dep:rustls", "dep:tokio-rustls", "dep:rcgen", "dep:axum", "dep:tower", "dep:qrcode"]
+client = []
+client-bin = ["client"]
+
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "time", "signal", "sync", "macros", "process"] }
 clap = { version = "4", features = ["derive"] }
@@ -38,22 +64,30 @@ anyhow = "1"
 thiserror = "1"
 bytes = "1"
 libc = "0.2"
+# Drop-in AtomicU64 etc. that work on 32-bit targets without native 64-bit atomics
+# (mipsel Keenetic routers). Maps to native instructions on aarch64/x86_64 — zero
+# cost there; lock-based fallback only where the target lacks the instruction.
+portable-atomic = "1"
 mio = { version = "1", features = ["os-poll", "os-ext"] }
 # SO_REUSEPORT UDP sockets for the multi-worker UDP data plane (safe sockaddr
 # handling vs hand-rolled libc). Already in the dep tree via tokio/mio.
 socket2 = { version = "0.5", features = ["all"] }
 
-axum = { version = "0.7", features = ["macros"] }
-tower = "0.5"
+# Web admin stack — server-only (feature = "server"). `ring` (pulled via rcgen/
+# rustls below) has no MIPS backend, so these stay out of the client-only build.
+axum = { version = "0.7", features = ["macros"], optional = true }
+tower = { version = "0.5", optional = true }
 base64 = "0.22"
 # Pure-Rust QR generation for the web UI share/QR feature (SVG output, no JS/CDN).
-qrcode = { version = "0.14", default-features = false, features = ["svg"] }
+qrcode = { version = "0.14", default-features = false, features = ["svg"], optional = true }
 
 # Real TLS 1.3 server-side termination for REALITY (M3). `ring` provider only
-# (the lab has no cmake for aws-lc-rs). The client side is hand-rolled (no rustls).
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-rcgen = { version = "0.14", default-features = false, features = ["ring"] }
+# (the lab has no cmake for aws-lc-rs). The client side is hand-rolled (no rustls),
+# so these are server-only (feature = "server") — `ring` is the lone MIPS blocker
+# and it lives entirely behind this gate.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"], optional = true }
+rcgen = { version = "0.14", default-features = false, features = ["ring"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # JNI bridge for the Android client (A4). Host/Windows use the plain C ABI (ffi.rs).

--- a/qeli/src/client/mod.rs
+++ b/qeli/src/client/mod.rs
@@ -13,7 +13,10 @@ use crate::tun::{
 };
 use rand::Rng;
 use std::os::fd::AsRawFd;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+// `portable_atomic::AtomicU64` so the data-plane byte counters compile on 32-bit
+// mipsel routers (no native 64-bit atomics); native instruction on aarch64/x86_64.
+use portable_atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};

--- a/qeli/src/client_main.rs
+++ b/qeli/src/client_main.rs
@@ -1,0 +1,85 @@
+//! Standalone qeli **client** binary for routers (Keenetic / Entware) and any
+//! headless Linux client. It drives only the `client` data plane — no server, no
+//! web admin, no `rustls`/`ring` — so it cross-compiles to mipsel/aarch64 musl.
+//!
+//! Built ONLY under the off-by-default `client-bin` feature (see Cargo.toml and
+//! docs/KEENETIC-PORT.md):
+//!
+//! ```sh
+//! cargo build --release --bin qeli-client \
+//!   --no-default-features --features client-bin --target <TARGET>
+//! ```
+//!
+//! The full `qeli` daemon (server + client + web) is still `src/main.rs`.
+
+#[cfg(not(target_os = "linux"))]
+compile_error!("qeli-client is Linux-only (it creates a TUN device via /dev/net/tun)");
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(
+    name = "qeli-client",
+    about = "Obfuscated VPN client (router/headless build)",
+    version
+)]
+struct Cli {
+    /// Client config (flat-INI, `[qeli]` section). Default suits Entware layout.
+    #[arg(short, long, default_value = "/opt/etc/qeli/client.conf")]
+    config: PathBuf,
+}
+
+/// Read the `[logging]` section (level + optional file) so logs land where the
+/// router operator expects. Mirrors `main.rs::peek_logging`; falls back to
+/// (info, stderr) on any error.
+fn peek_logging(path: &PathBuf) -> (String, Option<String>) {
+    if let Ok(s) = std::fs::read_to_string(path) {
+        if let Ok(doc) = qeli::config::format::IniDoc::parse(&s) {
+            if let Some(log) = doc.section("logging") {
+                let level = log.get_or("level", "info").to_string();
+                let file = log
+                    .get("file")
+                    .filter(|f| !f.is_empty())
+                    .map(str::to_string);
+                return (level, file);
+            }
+        }
+    }
+    ("info".to_string(), None)
+}
+
+fn init_logging(level: &str, file: Option<&str>) {
+    let mut builder =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(level));
+    if let Some(path) = file {
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            Ok(f) => {
+                builder.target(env_logger::Target::Pipe(Box::new(f)));
+            }
+            Err(e) => eprintln!("qeli-client: cannot open log file {path}: {e} — logging to stderr"),
+        }
+    }
+    builder.init();
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let (level, log_file) = peek_logging(&cli.config);
+    init_logging(&level, log_file.as_deref());
+
+    let config_str = cli.config.to_str().ok_or_else(|| {
+        anyhow::anyhow!("config path is not valid UTF-8: {}", cli.config.display())
+    })?;
+    log::info!("Starting qeli client with config: {}", cli.config.display());
+    qeli::client::run_client(config_str).await
+}

--- a/qeli/src/client_main.rs
+++ b/qeli/src/client_main.rs
@@ -64,7 +64,9 @@ fn init_logging(level: &str, file: Option<&str>) {
             Ok(f) => {
                 builder.target(env_logger::Target::Pipe(Box::new(f)));
             }
-            Err(e) => eprintln!("qeli-client: cannot open log file {path}: {e} — logging to stderr"),
+            Err(e) => {
+                eprintln!("qeli-client: cannot open log file {path}: {e} — logging to stderr")
+            }
         }
     }
     builder.init();

--- a/qeli/src/config/client.rs
+++ b/qeli/src/config/client.rs
@@ -345,6 +345,21 @@ impl ClientConfig {
         cfg.routing.route_local_networks =
             matches!(q.get("route_local"), Some("true") | Some("1") | Some("yes"));
 
+        // Ключи для роутера/шлюза (только в файле, в qeli://-ссылку НЕ входят —
+        // она для телефонов):
+        //   gateway = true → full-tunnel: весь трафик в VPN (клиент ставит default
+        //     через tun; в паре с NAT на роутере это заворачивает весь LAN). Дефолт
+        //     off (split-tunnel — только подсеть туннеля).
+        //   dns = off → НЕ управлять резолвером хоста: на роутере /etc/resolv.conf
+        //     принадлежит прошивке (ndnsproxy/dnsmasq). dns.rs делает early-return
+        //     при mode != "tunnel". Дефолт "tunnel".
+        if matches!(q.get("gateway"), Some("true") | Some("1") | Some("yes")) {
+            cfg.routing.add_default_gateway = true;
+        }
+        if let Some(d) = q.get("dns").filter(|s| !s.is_empty()) {
+            cfg.dns.mode = d.to_string();
+        }
+
         if let Some(log) = doc.section("logging") {
             cfg.logging.level = log.get_or("level", "info").to_string();
             cfg.logging.file = log
@@ -448,6 +463,12 @@ impl ClientConfig {
         if self.routing.route_local_networks {
             q.set("route_local", "true");
         }
+        if self.routing.add_default_gateway {
+            q.set("gateway", "true");
+        }
+        if self.dns.mode != "tunnel" {
+            q.set("dns", &self.dns.mode);
+        }
         if self.tun.name != "vpn0" {
             q.set("dev", &self.tun.name);
         }
@@ -549,5 +570,25 @@ sni    = www.cloudflare.com
         assert_eq!(c.tun.name, "vpn7");
         let back = ClientConfig::from_ini(&IniDoc::parse(&c.to_ini_string()).unwrap()).unwrap();
         assert_eq!(back.tun.name, "vpn7");
+    }
+
+    #[test]
+    fn router_gateway_and_dns_keys() {
+        // gateway/dns — файловые ключи для роутера (full-tunnel + не трогать DNS).
+        let src = "[qeli]\nserver = h:443\nuser = u\npass = p\ngateway = true\ndns = off\n";
+        let c = ClientConfig::from_ini(&IniDoc::parse(src).unwrap()).unwrap();
+        assert!(c.routing.add_default_gateway);
+        assert_eq!(c.dns.mode, "off");
+        // переживают round-trip через to_ini_string()
+        let back = ClientConfig::from_ini(&IniDoc::parse(&c.to_ini_string()).unwrap()).unwrap();
+        assert!(back.routing.add_default_gateway);
+        assert_eq!(back.dns.mode, "off");
+        // дефолты без ключей: split-tunnel + dns=tunnel
+        let d = ClientConfig::from_ini(
+            &IniDoc::parse("[qeli]\nserver = h:443\nuser = u\npass = p\n").unwrap(),
+        )
+        .unwrap();
+        assert!(!d.routing.add_default_gateway);
+        assert_eq!(d.dns.mode, "tunnel");
     }
 }

--- a/qeli/src/lib.rs
+++ b/qeli/src/lib.rs
@@ -9,17 +9,22 @@ pub mod config;
 pub mod crypto;
 pub mod protocol;
 // Transport-trait scaffolding for the planned TCP/UDP unification (ROADMAP P1#2);
-// not yet wired into handler.rs/udp_handler.rs. Linux-only (uses libc socket
-// options); the cross-platform realtls FFI doesn't need it.
+// not yet fully wired, but the client already uses `transport::tcp::set_tcp_keepalive`,
+// so it builds in both the client-only and the full daemon builds. `ring`-free, so
+// it cross-compiles to mipsel/aarch64.
 #[cfg(target_os = "linux")]
 #[allow(dead_code)]
 pub mod transport;
 
-#[cfg(target_os = "linux")]
+// `client`/`tun` build under feature = "client"; `server`/`web` under
+// feature = "server". Default features enable both, so a normal build is
+// unchanged. A router (Keenetic) build uses `--no-default-features --features
+// client-bin` to drop the server/web stack (and its MIPS-incompatible `ring`).
+#[cfg(all(target_os = "linux", feature = "client"))]
 pub mod client;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "server"))]
 pub mod server;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "client"))]
 pub mod tun;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "server"))]
 pub mod web;

--- a/qeli/src/protocol/realtls/mod.rs
+++ b/qeli/src/protocol/realtls/mod.rs
@@ -21,5 +21,10 @@ pub mod jni;
 pub mod keyschedule;
 pub mod record;
 pub mod sansio;
+// Server-side TLS 1.3 termination — the only `rustls`/`ring` user in realtls.
+// Gated so the client-only router build (no `server` feature) excludes `ring`
+// (no MIPS backend). Client submodules above are hand-rolled and stay portable.
+// (Tests in ffi/sansio/stream reference this; they run with default features.)
+#[cfg(feature = "server")]
 pub mod server;
 pub mod stream;

--- a/qeli/src/tun/iface.rs
+++ b/qeli/src/tun/iface.rs
@@ -5,6 +5,13 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 
+// Запрос ioctl TUNSETIFF. Кодировка `_IOW` на MIPS отличается от asm-generic
+// (x86/arm/arm64), поэтому ЗНАЧЕНИЕ арк-специфично (0x800454ca против 0x400454ca).
+// ТИП запроса тоже зависит от платформы (`c_ulong` на glibc, `c_int` на musl) —
+// кастуем `as _` на месте вызова (см. ниже).
+#[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+const TUNSETIFF: libc::c_ulong = 0x800454ca;
+#[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
 const TUNSETIFF: libc::c_ulong = 0x400454ca;
 const IFF_TUN: libc::c_short = 0x0001;
 const IFF_TAP: libc::c_short = 0x0002;
@@ -98,7 +105,8 @@ impl TunInterface {
         let ret = unsafe {
             libc::ioctl(
                 fd.as_raw_fd(),
-                TUNSETIFF,
+                // `as _`: тип запроса — c_ulong (glibc) или c_int (musl).
+                TUNSETIFF as _,
                 &ifr as *const _ as *const libc::c_void,
             )
         };

--- a/release/keenetic/README.md
+++ b/release/keenetic/README.md
@@ -1,7 +1,8 @@
 # qeli-client на Keenetic (Entware) — деплой
 
-Запуск qeli-VPN-клиента на роутере Keenetic как шлюза для всего LAN. Полный план и
-обоснование — [docs/KEENETIC-PORT.md](../../docs/KEENETIC-PORT.md).
+Запуск qeli-VPN-клиента на роутере Keenetic как шлюза для всего LAN.
+**Подробный пошаговый гайд (по шагам, с проверкой туннеля) — [docs/KEENETIC-DEPLOY.md](../../docs/KEENETIC-DEPLOY.md).**
+План и обоснование порта — [docs/KEENETIC-PORT.md](../../docs/KEENETIC-PORT.md).
 
 > ⚠️ Скрипты в этой папке — **шаблоны**. На живом Кинетике они не тестировались
 > (у нас нет устройства); проверь имена интерфейсов и поведение firewall под свою

--- a/release/keenetic/README.md
+++ b/release/keenetic/README.md
@@ -1,0 +1,45 @@
+# qeli-client на Keenetic (Entware) — деплой
+
+Запуск qeli-VPN-клиента на роутере Keenetic как шлюза для всего LAN. Полный план и
+обоснование — [docs/KEENETIC-PORT.md](../../docs/KEENETIC-PORT.md).
+
+> ⚠️ Скрипты в этой папке — **шаблоны**. На живом Кинетике они не тестировались
+> (у нас нет устройства); проверь имена интерфейсов и поведение firewall под свою
+> модель/прошивку.
+
+## Предусловия на роутере
+- Установлен **Entware** (opkg, `/opt`).
+- Включён компонент **VPN** в KeeneticOS (чтобы был `/dev/net/tun`).
+- Есть SSH-доступ.
+
+## Сборка бинарей (на лабе .10)
+```sh
+python scripts/build_keenetic.py
+# → release/keenetic/qeli-client-aarch64  и  qeli-client-mipsel
+```
+
+## Установка (на роутере)
+Скопируй всю папку `release/keenetic/` на роутер (scp) и запусти:
+```sh
+sh install-keenetic.sh      # определит арку, поставит ip-full/iptables, разложит файлы
+vi /opt/etc/qeli/client.conf
+/opt/etc/init.d/S99qeli start
+tail -f /opt/var/log/qeli-client.log   # ждём 'Auth OK'
+```
+
+## Режим шлюза (весь LAN через VPN)
+- В `client.conf`: `gateway = true` (full-tunnel) и `dns = off` (не трогать DNS роутера).
+- `S99qeli` при `GATEWAY=yes` ставит `ip_forward` + `MASQUERADE` на tun и FORWARD-правила
+  между `LAN_IF` (по умолчанию `br0`) и tun. Проверь имя LAN-бриджа: `ip a`.
+
+## Выбор режима под железо
+- **MIPS** (MT7621/7628, без AES-NI): `fake-tls` / `obfs` / `plain` (ChaCha20). Потолок —
+  десятки Мбит. `reality-tls` очень медленный (двойной AEAD).
+- **ARM** (Cortex-A53, crypto-ext): можно `reality-tls`; скорость в разы выше.
+
+## Удаление
+```sh
+/opt/etc/init.d/S99qeli stop
+rm -f /opt/etc/init.d/S99qeli /opt/bin/qeli-client
+rm -rf /opt/etc/qeli
+```

--- a/release/keenetic/S99qeli
+++ b/release/keenetic/S99qeli
@@ -1,0 +1,68 @@
+#!/bin/sh
+# /opt/etc/init.d/S99qeli — запуск qeli-client на Keenetic (Entware).
+# Управление: /opt/etc/init.d/S99qeli {start|stop|restart|status}
+# ⚠️ ШАБЛОН: проверь LAN_IF и имя tun под свою модель/прошивку (`ip a`).
+
+BIN=/opt/bin/qeli-client
+CONF=/opt/etc/qeli/client.conf
+PIDFILE=/opt/var/run/qeli-client.pid
+LOG=/opt/var/log/qeli-client.log
+TUN=vpn0            # имя tun (должно совпадать с dev= в конфиге; дефолт vpn0)
+LAN_IF=br0          # LAN-бридж роутера (проверь `ip a` — бывает br0/bridge0)
+GATEWAY=yes         # yes = ставить NAT/forward для заворота всего LAN (full-tunnel)
+
+# device-id на персистентном пути: /opt/var (на роутере /var = tmpfs и теряется при
+# ребуте → сервер каждый раз видел бы «новое устройство» и тратил слот сессии).
+export QELI_DEVICE_ID_FILE=/opt/etc/qeli/device-id
+export PATH=/opt/sbin:/opt/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+nat_up() {
+  [ "$GATEWAY" = yes ] || return 0
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+  iptables -t nat -C POSTROUTING -o "$TUN" -j MASQUERADE 2>/dev/null || \
+    iptables -t nat -A POSTROUTING -o "$TUN" -j MASQUERADE
+  iptables -C FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT
+  iptables -C FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT
+}
+
+nat_down() {
+  [ "$GATEWAY" = yes ] || return 0
+  iptables -t nat -D POSTROUTING -o "$TUN" -j MASQUERADE 2>/dev/null
+  iptables -D FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT 2>/dev/null
+  iptables -D FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null
+}
+
+is_running() { [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; }
+
+start() {
+  if is_running; then echo "qeli-client уже запущен (pid $(cat "$PIDFILE"))"; return 0; fi
+  if [ ! -e /dev/net/tun ]; then
+    echo "нет /dev/net/tun — включи компонент VPN в KeeneticOS"; exit 1
+  fi
+  mkdir -p /opt/var/run /opt/var/log /opt/etc/qeli
+  echo "qeli-client: старт"
+  "$BIN" --config "$CONF" >> "$LOG" 2>&1 &
+  echo $! > "$PIDFILE"
+  sleep 1
+  nat_up
+}
+
+stop() {
+  echo "qeli-client: стоп"
+  nat_down
+  if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" 2>/dev/null
+    rm -f "$PIDFILE"
+  fi
+  ip link del "$TUN" 2>/dev/null   # подчистить tun, если остался
+}
+
+case "$1" in
+  start)   start ;;
+  stop)    stop ;;
+  restart) stop; sleep 1; start ;;
+  status)  is_running && echo "running (pid $(cat "$PIDFILE"))" || echo "stopped" ;;
+  *) echo "usage: $0 {start|stop|restart|status}"; exit 1 ;;
+esac

--- a/release/keenetic/client.conf.example
+++ b/release/keenetic/client.conf.example
@@ -1,0 +1,37 @@
+# qeli — клиентский конфиг для роутера Keenetic (flat-INI, секция [qeli]).
+# Проще всего получить connection-часть из qeli://-ссылки, выданной сервером:
+#   qeli add-client <user> --link --host <addr>
+# затем добавить router-ключи gateway/dns (см. ниже).
+# ВАЖНО: комментарии — на ОТДЕЛЬНОЙ строке (inline-комментарии не срезаются).
+
+[qeli]
+# host:port сервера
+server = vpn.example.com:443
+# tcp | udp — должно совпадать с профилем сервера
+proto = tcp
+user = router1
+pass = СМЕНИ_МЕНЯ
+# Пиннинг публичного ключа сервера (анти-MITM). Возьми на сервере: qeli show-identity
+# Пусто / все нули = TOFU (доверие при первом подключении).
+key = 0000000000000000000000000000000000000000000000000000000000000000
+# Режим маскировки — должен совпадать с сервером. На MIPS-кинетиках бери лёгкие
+# по CPU: fake-tls | obfs | plain (ChaCha20). reality-tls на mipsel очень медленный
+# (двойной AEAD) — разумен только на ARM-моделях.
+mode = fake-tls
+# SNI для fake-tls (фронт-домен). Для obfs не нужен.
+sni = www.cloudflare.com
+# obfs_key = общий-секрет      # обязателен для mode = obfs
+
+# ── Router / шлюз ────────────────────────────────────────────────────────────
+# gateway=true → full-tunnel: весь трафик в VPN. В паре с NAT в init-скрипте
+# (S99qeli) заворачивает весь LAN роутера через туннель.
+gateway = true
+# dns=off → НЕ трогать /etc/resolv.conf роутера (им владеет прошивка Keenetic).
+# DNS для LAN-клиентов остаётся на штатном резолвере роутера (ndnsproxy/dnsmasq).
+dns = off
+# Имя tun-интерфейса (дефолт vpn0). Поменяй, если vpn0 занят штатным VPN роутера.
+# dev = qeli0
+
+[logging]
+level = info
+file = /opt/var/log/qeli-client.log

--- a/release/keenetic/install-keenetic.sh
+++ b/release/keenetic/install-keenetic.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Установка qeli-client на Keenetic (Entware). Запускать НА РОУТЕРЕ по SSH из папки,
+# где лежат бинари (qeli-client-{aarch64,mipsel}) и шаблоны (S99qeli, client.conf.example).
+set -e
+PKGDIR="$(cd "$(dirname "$0")" && pwd)"
+
+# 1. Определяем арку по пакетному фиду Entware
+ARCH="$(opkg print-architecture | awk '{print $2}' | grep -E 'aarch64|mipsel|mips' | head -n1)"
+echo "арка пакетов: ${ARCH:-неизвестна} (uname -m: $(uname -m))"
+case "$ARCH" in
+  *aarch64*) BINSRC="qeli-client-aarch64" ;;
+  *mipsel*)  BINSRC="qeli-client-mipsel" ;;
+  *) echo "арка '$ARCH' не поддерживается (big-endian mips не собирается)"; exit 1 ;;
+esac
+[ -f "$PKGDIR/$BINSRC" ] || { echo "нет $BINSRC рядом со скриптом"; exit 1; }
+
+# 2. Зависимости: ip-full (busybox ip без tuntap/route get), iptables (NAT для шлюза)
+opkg update
+opkg install ip-full iptables || true
+
+# 3. Проверка /dev/net/tun
+[ -e /dev/net/tun ] || echo "ВНИМАНИЕ: нет /dev/net/tun — включи компонент VPN в KeeneticOS"
+
+# 4. Раскладка
+install -m755 "$PKGDIR/$BINSRC" /opt/bin/qeli-client
+mkdir -p /opt/etc/qeli /opt/var/log /opt/var/run
+if [ ! -f /opt/etc/qeli/client.conf ]; then
+  install -m600 "$PKGDIR/client.conf.example" /opt/etc/qeli/client.conf
+  echo "положил болванку /opt/etc/qeli/client.conf — ОТРЕДАКТИРУЙ её"
+fi
+install -m755 "$PKGDIR/S99qeli" /opt/etc/init.d/S99qeli
+
+echo
+echo "Готово. Дальше:"
+echo "  1) vi /opt/etc/qeli/client.conf   # server/user/pass/key/mode + gateway/dns"
+echo "  2) /opt/etc/init.d/S99qeli start"
+echo "  3) tail -f /opt/var/log/qeli-client.log   # ищи 'Auth OK'"

--- a/scripts/build_keenetic.py
+++ b/scripts/build_keenetic.py
@@ -1,0 +1,126 @@
+"""Кросс-сборка client-only бинаря qeli под роутеры Keenetic — обе арки за прогон.
+
+  aarch64-unknown-linux-musl  — новые ARM-кинетики (Cortex-A53); stable + zig-линкер.
+  mipsel-unknown-linux-musl   — основной парк (MT7621/7628); tier-3 → nightly -Zbuild-std.
+
+Линкер/cc для обеих арок — zig (уже стоит на .10) через cargo-zigbuild. Сборка
+client-only (`--no-default-features --features client-bin`) → без `ring` (нет MIPS).
+Скрипт idempotent: ставит недостающие компоненты тулчейна, потом собирает; не падает
+на первой ошибке — печатает оба результата. Готовые бинари тянет в release/keenetic/.
+
+Креды из QELI_LAB_PASS. Запуск:
+    $env:QELI_LAB_PASS="..."; python scripts/build_keenetic.py
+"""
+import os, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+sys.path.insert(0, os.path.dirname(__file__))
+from lab_common import connect, LAB_SRV
+
+REMOTE_ROOT = "/opt/qeli-src"
+LOCAL_OUT = r"C:\Users\litvi\OneDrive\Documents\OpenCode\VPN_CLAUDE\release\keenetic"
+TARGETS = {
+    "aarch64": "aarch64-unknown-linux-musl",
+    "mipsel": "mipsel-unknown-linux-musl",
+}
+CLIENT_FEATURES = "--no-default-features --features client-bin"
+BIN = "qeli-client"
+
+
+def run(c, cmd, t=120):
+    """Выполнить команду; вернуть (rc, combined_out). lab_common.run отдаёт только
+    строку — а здесь нужен реальный exit-код, чтобы судить об успехе сборки."""
+    _i, o, e = c.exec_command(cmd, timeout=t)
+    out = o.read().decode("utf-8", "replace") + e.read().decode("utf-8", "replace")
+    rc = o.channel.recv_exit_status()
+    return rc, out.strip()
+
+
+def tail(s, n=25):
+    return "\n".join(s.splitlines()[-n:])
+
+
+def ensure_toolchain(c):
+    print("### Сетап тулчейна (idempotent)")
+    # nightly + rust-src — для -Zbuild-std под tier-3 mipsel
+    _, nl = run(c, "rustup toolchain list | grep -q nightly && echo YES || echo NO")
+    if "NO" in nl:
+        print("  ставлю nightly + rust-src...")
+        _, o = run(c, "rustup toolchain install nightly --profile minimal -c rust-src 2>&1 | tail -3", t=600)
+        print(o)
+    else:
+        run(c, "rustup component add rust-src --toolchain nightly 2>/dev/null; true")
+        print("  nightly уже есть (+ гарантирую rust-src)")
+    # aarch64-musl std (tier-2, ставится из rustup)
+    _, o = run(c, "rustup target add aarch64-unknown-linux-musl 2>&1 | tail -1", t=300)
+    print("  aarch64-musl target:", o or "ok")
+    # cargo-zigbuild (zig как линкер для обеих арок)
+    _, zb = run(c, "cargo zigbuild --version 2>/dev/null || echo none")
+    if "zigbuild" not in zb:
+        print("  ставлю cargo-zigbuild...")
+        _, o = run(c, "cargo install cargo-zigbuild --locked 2>&1 | tail -3", t=1200)
+        print(o)
+    else:
+        print("  cargo-zigbuild уже есть:", zb)
+    _, zv = run(c, "zig version")
+    print("  zig:", zv)
+    print()
+
+
+def build(c, arch, target):
+    print(f"### Сборка {arch} ({target})")
+    if arch == "mipsel":
+        # tier-3: nightly + сборка std из исходников. Rust компилит mipsel в soft-float
+        # ABI, а zig по умолчанию линкует mips как fpxx → конфликт float-ABI на линковке.
+        # Принуждаем линковку к soft-float (бинарь не использует FPU — идёт на любом mips).
+        cmd = (f"cd {REMOTE_ROOT} && RUSTFLAGS='-C link-arg=-msoft-float' "
+               f"cargo +nightly zigbuild "
+               f"-Z build-std=std,panic_abort --release --bin {BIN} "
+               f"{CLIENT_FEATURES} --target {target} 2>&1")
+    else:
+        cmd = (f"cd {REMOTE_ROOT} && cargo zigbuild --release --bin {BIN} "
+               f"{CLIENT_FEATURES} --target {target} 2>&1")
+    rc, out = run(c, cmd, t=1800)
+    print(tail(out, 25))
+    print(f"{arch} build rc:", rc)
+    if rc == 0:
+        _, info = run(c, f"file {REMOTE_ROOT}/target/{target}/release/{BIN}; "
+                         f"ls -lh {REMOTE_ROOT}/target/{target}/release/{BIN} | awk '{{print $5}}'")
+        print("  artifact:", info)
+    print()
+    return rc
+
+
+def pull(c, arch, target):
+    src = f"{REMOTE_ROOT}/target/{target}/release/{BIN}"
+    os.makedirs(LOCAL_OUT, exist_ok=True)
+    dst = os.path.join(LOCAL_OUT, f"{BIN}-{arch}")
+    sf = c.open_sftp()
+    try:
+        sf.get(src, dst); print(f"  стянул {arch} → {dst}")
+    except IOError as e:
+        print(f"  не удалось стянуть {arch}: {e}")
+    finally:
+        sf.close()
+
+
+def main():
+    # Опц. фильтр арки: `python build_keenetic.py mipsel` собирает только её.
+    sel = sys.argv[1] if len(sys.argv) > 1 else None
+    targets = {sel: TARGETS[sel]} if sel in TARGETS else TARGETS
+    c = connect(LAB_SRV)
+    print("Подключено к", LAB_SRV[0], "\n")
+    ensure_toolchain(c)
+    results = {}
+    for arch, target in targets.items():
+        results[arch] = build(c, arch, target)
+        if results[arch] == 0:
+            pull(c, arch, target)
+    c.close()
+    print("\n===== ИТОГ =====")
+    for arch in targets:
+        print(f"  {arch}: {'OK' if results.get(arch) == 0 else 'FAIL'}")
+    print("KEENETIC_BUILD:", "PASS" if all(v == 0 for v in results.values()) else "PARTIAL/FAIL")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/keenetic_toolchain_probe.py
+++ b/scripts/keenetic_toolchain_probe.py
@@ -1,0 +1,41 @@
+"""Разведка тулчейна на лаб-сервере .10 под Фазу 2 (кросс-сборка Keenetic).
+
+Печатает инвентарь: rustup-тулчейны/таргеты, nightly + rust-src (нужны для
+tier-3 mipsel через -Zbuild-std), zig/cargo-zigbuild и поддержку zig'ом
+mipsel/aarch64 linux-musl. По выхлопу решаем: zigbuild для обеих арок или
+OpenWrt SDK для mipsel.
+
+Креды из QELI_LAB_PASS. Запуск:
+    $env:QELI_LAB_PASS="..."; python scripts/keenetic_toolchain_probe.py
+"""
+import os, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+sys.path.insert(0, os.path.dirname(__file__))
+from lab_common import connect, run, LAB_SRV
+
+CMDS = [
+    ("rustc / cargo",            "rustc --version; cargo --version"),
+    ("rustup toolchains",        "rustup toolchain list"),
+    ("targets (default)",        "rustup target list --installed"),
+    ("nightly есть?",            "rustup toolchain list | grep -q nightly && echo YES || echo NO"),
+    ("nightly rust-src?",        "rustup component list --toolchain nightly 2>/dev/null | grep 'rust-src (installed)' || echo 'нет nightly/rust-src'"),
+    ("целевые linux-musl таргеты","rustup target list | grep -E 'mipsel-unknown-linux-musl|aarch64-unknown-linux-musl|^mips-unknown-linux-musl' || true"),
+    ("zig",                      "which zig && zig version || echo 'нет zig'"),
+    ("cargo-zigbuild",           "cargo zigbuild --version 2>/dev/null || echo 'нет cargo-zigbuild'"),
+    ("zig умеет mipsel/aarch64", "zig targets 2>/dev/null | grep -oE '\"(mipsel|aarch64|mips)\"' | sort -u || echo 'zig targets failed'"),
+    ("musl-cross линкеры",       "ls /usr/bin /usr/local/bin 2>/dev/null | grep -E 'musl-gcc|openwrt|mipsel.*gcc|aarch64.*linux.*gcc' || echo 'нет явных musl-cross gcc'"),
+]
+
+
+def main():
+    c = connect(LAB_SRV)
+    print("Подключено к", LAB_SRV[0], "\n")
+    for label, cmd in CMDS:
+        print(f"### {label}")
+        print(run(c, cmd, timeout=60))
+        print()
+    c.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/keenetic_verify.py
+++ b/scripts/keenetic_verify.py
@@ -81,6 +81,10 @@ def main():
     rc_def, o_def = run(c, f"cd {REMOTE_ROOT} && cargo build --release 2>&1")
     print(tail(o_def, 20)); print("default build rc:", rc_def)
 
+    print("\n=== [1b] unit tests (default features): cargo test --lib ===")
+    rc_test, o_test = run(c, f"cd {REMOTE_ROOT} && cargo test --lib 2>&1")
+    print(tail(o_test, 12)); print("test rc:", rc_test)
+
     print("\n=== [2] CLIENT-ONLY build: --no-default-features --features client-bin ===")
     rc_cli, o_cli = run(c, f"cd {REMOTE_ROOT} && cargo build --release --bin qeli-client "
                            f"--no-default-features --features client-bin 2>&1")
@@ -104,9 +108,10 @@ def main():
     run(c, "systemctl start qeli-server.service 2>/dev/null; true", t=30)
     c.close()
 
-    ok = (rc_def == 0 and rc_cli == 0 and rc_clp == 0 and ring_absent)
+    ok = (rc_def == 0 and rc_test == 0 and rc_cli == 0 and rc_clp == 0 and ring_absent)
     print("\n===== SUMMARY =====")
     print(f"default_build={'OK' if rc_def==0 else 'FAIL'}  "
+          f"unit_tests={'OK' if rc_test==0 else 'FAIL'}  "
           f"client_build={'OK' if rc_cli==0 else 'FAIL'}  "
           f"client_clippy={'OK' if rc_clp==0 else 'FAIL'}  "
           f"ring_absent={'OK' if ring_absent else 'FAIL'}")

--- a/scripts/keenetic_verify.py
+++ b/scripts/keenetic_verify.py
@@ -1,0 +1,117 @@
+"""Verify the Keenetic Phase-1 refactor on the lab server (10.66.116.10).
+
+Two things must hold:
+  1. The DEFAULT build (server+client) is unregressed by making the server deps
+     optional / the module gating / the portable-atomic swap.
+  2. The new client-only path compiles WITHOUT `ring`:
+       cargo build --release --bin qeli-client --no-default-features --features client-bin
+     and `cargo tree -i ring` confirms `ring` is absent from that feature graph.
+
+Creds from QELI_LAB_PASS (see scripts/lab_env.sh / memory). Run:
+    $env:QELI_LAB_PASS="..."; python scripts/keenetic_verify.py
+"""
+import os, sys, posixpath, time
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+import paramiko
+
+SERVER = (os.environ.get("QELI_LAB_SERVER", "10.66.116.10"), "root",
+          os.environ.get("QELI_LAB_PASS", ""))
+LOCAL_ROOT = r"C:\Users\litvi\OneDrive\Documents\OpenCode\VPN_CLAUDE\qeli"
+REMOTE_ROOT = "/opt/qeli-src"
+
+
+def conn(h):
+    c = paramiko.SSHClient(); c.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    c.connect(h[0], username=h[1], password=h[2], timeout=20,
+              look_for_keys=False, allow_agent=False)
+    return c
+
+
+def run(c, cmd, t=1200):
+    i, o, e = c.exec_command(cmd, timeout=t)
+    out = o.read().decode("utf-8", "replace") + e.read().decode("utf-8", "replace")
+    rc = o.channel.recv_exit_status()
+    return rc, out.strip()
+
+
+def sync_tree(c):
+    sf = c.open_sftp(); made = set()
+    def ensure(d):
+        if d in made or d in ("", "/"):
+            return
+        ensure(posixpath.dirname(d))
+        try: sf.stat(d)
+        except IOError:
+            try: sf.mkdir(d)
+            except IOError: pass
+        made.add(d)
+    files = []
+    for dp, _dn, fn in os.walk(os.path.join(LOCAL_ROOT, "src")):
+        for f in fn:
+            files.append(os.path.join(dp, f))
+    for extra in ("Cargo.toml", "Cargo.lock"):
+        p = os.path.join(LOCAL_ROOT, extra)
+        if os.path.exists(p): files.append(p)
+    n = 0
+    for lp in files:
+        rel = os.path.relpath(lp, LOCAL_ROOT).replace("\\", "/")
+        rp = posixpath.join(REMOTE_ROOT, rel)
+        ensure(posixpath.dirname(rp))
+        sf.put(lp, rp); n += 1
+    sf.close(); return n
+
+
+def tail(s, n):
+    return "\n".join(s.splitlines()[-n:])
+
+
+def main():
+    if not SERVER[2]:
+        print("QELI_LAB_PASS not set — aborting"); sys.exit(2)
+    c = conn(SERVER); print("Connected to", SERVER[0])
+    run(c, "systemctl stop qeli-server.service 2>/dev/null; pkill -9 -x qeli 2>/dev/null; true", t=30)
+    # The client entrypoint moved out of src/bin/ (gitignored `**/bin/`). Drop any
+    # stale src/bin/ on the remote so cargo's bin auto-discovery can't resurrect an
+    # orphaned qeli-client.rs and collide with the explicit [[bin]] in Cargo.toml.
+    run(c, "rm -rf /opt/qeli-src/src/bin", t=30)
+    t0 = time.time(); n = sync_tree(c)
+    print(f"Synced {n} files to {REMOTE_ROOT} in {time.time()-t0:.0f}s")
+
+    print("\n=== [1] DEFAULT build (regression): cargo build --release ===")
+    rc_def, o_def = run(c, f"cd {REMOTE_ROOT} && cargo build --release 2>&1")
+    print(tail(o_def, 20)); print("default build rc:", rc_def)
+
+    print("\n=== [2] CLIENT-ONLY build: --no-default-features --features client-bin ===")
+    rc_cli, o_cli = run(c, f"cd {REMOTE_ROOT} && cargo build --release --bin qeli-client "
+                           f"--no-default-features --features client-bin 2>&1")
+    print(tail(o_cli, 25)); print("client-bin build rc:", rc_cli)
+
+    print("\n=== [3] CLIENT-ONLY clippy ===")
+    rc_clp, o_clp = run(c, f"cd {REMOTE_ROOT} && cargo clippy --bin qeli-client "
+                           f"--no-default-features --features client-bin -- -D warnings 2>&1")
+    print(tail(o_clp, 20)); print("client-bin clippy rc:", rc_clp)
+
+    print("\n=== [4] ring absent from client graph? (cargo tree -i ring) ===")
+    _rc_tree, o_tree = run(c, f"cd {REMOTE_ROOT} && cargo tree --no-default-features "
+                              f"--features client-bin -i ring 2>&1")
+    ring_absent = ("did not match any packages" in o_tree) or ("nothing to print" in o_tree)
+    print(tail(o_tree, 8)); print("ring ABSENT from client build:", ring_absent)
+
+    # sanity: the produced binary exists + is a Linux ELF
+    _rc, finfo = run(c, f"file {REMOTE_ROOT}/target/release/qeli-client 2>&1")
+    print("\nqeli-client binary:", finfo)
+
+    run(c, "systemctl start qeli-server.service 2>/dev/null; true", t=30)
+    c.close()
+
+    ok = (rc_def == 0 and rc_cli == 0 and rc_clp == 0 and ring_absent)
+    print("\n===== SUMMARY =====")
+    print(f"default_build={'OK' if rc_def==0 else 'FAIL'}  "
+          f"client_build={'OK' if rc_cli==0 else 'FAIL'}  "
+          f"client_clippy={'OK' if rc_clp==0 else 'FAIL'}  "
+          f"ring_absent={'OK' if ring_absent else 'FAIL'}")
+    print("KEENETIC_PHASE1:", "PASS" if ok else "FAIL")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Что это
Порт qeli-VPN-клиента на роутеры **Keenetic** (Entware), сразу под обе арки модельного
ряда: **MIPS (mipsel)** и **ARM (aarch64)**. Переиспользует существующий Linux-демон —
новый нативный клиент не пишется. План целиком: `docs/KEENETIC-PORT.md`.

## Сделано
- **Фаза 1 — client-only сборка.** Фич-флаги `server`/`client`/`client-bin`; серверные
  депы (rustls/ring/axum/tower/qrcode/rcgen) → `optional`. `ring` (нет MIPS-бэкенда) убран
  из клиента; `AtomicU64` → `portable_atomic` (32-бит mipsel без 64-бит атомиков). Отдельный
  bin `qeli-client` (`src/client_main.rs`). `default = server+client` → обычная сборка
  байт-идентична прежней; серверные/CI/FFI-сборки не затронуты.
- **Фаза 1.5 — ключи `[qeli]` для роутера:** `gateway=true` (full-tunnel) и `dns=off`
  (не трогать резолвер роутера). В qeli://-ссылку не входят.
- **Фаза 2 — кросс-сборка** через zig 0.13 + cargo-zigbuild (OpenWrt SDK не нужен):
  aarch64 (static, 2.3 МБ) и mipsel (static-pie MIPS32r2, 3.3 МБ). Исправлены арк-баги,
  видимые ТОЛЬКО при кросс-сборке: `TUNSETIFF` (тип запроса ioctl `c_int` на musl + значение
  `0x800454ca` на MIPS) и float-ABI mipsel (Rust soft-float vs zig fpxx → `-msoft-float`).
- **Фаза 3 — деплой на Entware** (`release/keenetic/`): `install-keenetic.sh`, `S99qeli`
  (init + NAT/forward + персистентный `QELI_DEVICE_ID_FILE`), `client.conf.example`, `README`.

## Проверка (лаб .10)
- Дефолтная `cargo build --release` не сломана; **180 юнит-тестов** зелёные.
- client-bin собирается без `ring` (`cargo tree -i ring` пусто); clippy `-D warnings` чисто.
- Обе кросс-арки собираются в статические бинари.

## Осталось
- CI-матрица (обе арки в `ci.yml`).
- Проверка и замеры на живом Кинетике (нет устройства): арка, `/dev/net/tun`, имена
  интерфейсов, взаимодействие с firewall/NAT KeeneticOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)