### PR TITLE
Android: fix QS tile long-press opening OS App Info instead of the app

### DIFF
--- a/qeli-android/app/src/main/AndroidManifest.xml
+++ b/qeli-android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,13 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="qeli" />
             </intent-filter>
+            <!-- Long-pressing the Quick Settings tile fires QS_TILE_PREFERENCES scoped to our
+                 package; without an activity that resolves it, SystemUI falls back to the OS
+                 App Info page. Handle it here so a long-press opens the app instead. -->
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <service


### PR DESCRIPTION
Long-pressing the Quick Settings tile fires an intent with action QS_TILE_PREFERENCES scoped to our package. No activity resolved it, so SystemUI fell back to the OS "App Info" (О приложении) screen instead of opening the app.

Add an intent-filter for android.service.quicksettings.action.QS_TILE_PREFERENCES (with CATEGORY_DEFAULT) to MainActivity so the long-press resolves to the app. MainActivity survives the intent cleanly: maybeAutoConnect/handleDeepLink key off EXTRA_AUTO_CONNECT and qeli:// data, neither of which a QS intent carries, so both no-op and the app just opens on its main screen.

Manifest-only change; XML validated with xmllint. Not built here — Gradle did not finish in this environment.