### PR TITLE
feat(keenetic): OpkgTun web-UI add-on + generic dev_attach

### DIFF
--- a/docs/ru/KEENETIC-DEPLOY.md
+++ b/docs/ru/KEENETIC-DEPLOY.md
@@ -107,15 +107,18 @@ pass   = <пароль>
 # Пиннинг статического ключа сервера (анти-MITM). Пусто/все нули = TOFU.
 key    = <server pubkey из show-identity>
 # H-1 (с 0.7.1, ВКЛ по умолчанию): привязка сессионных ключей к статике сервера.
-# ТРЕБУЕТ реального key. С TOFU-ключом (нули) поставь false; с реальным key — оставь
-# по умолчанию (можно удалить строку). Безопаснее: впиши реальный key и bind_static=true.
+# ДОЛЖНА СОВПАДАТЬ с сервером (у обоих дефолт true). ТРЕБУЕТ реального key. С TOFU-ключом
+# (нули) поставь false; с реальным key — оставь по умолчанию (удали строку). Если у клиента
+# false, а у сервера дефолт true — коннект упадёт с «decryption failed» после хендшейка.
 bind_static = false
 # Режим маскировки — должен совпадать с сервером. MIPS: fake-tls | obfs | plain
 # (ChaCha20). reality-tls на mipsel очень медленный (двойной AEAD) — только для ARM.
 mode   = fake-tls
 # SNI для fake-tls (фронт-домен). Для obfs не нужен.
 sni    = www.cloudflare.com
-# reality_sid = <hex>   # ТОЛЬКО для mode = reality-tls (с 0.7.1 short_id обязателен)
+# reality_sid = <hex>   # ТОЛЬКО для mode = reality-tls (с 0.7.1 short_id обязателен).
+#                       # reality-tls ТРЕБУЕТ реального key → убери `bind_static = false`
+#                       # (оставь дефолт true), иначе «decryption failed».
 
 # ── Router / шлюз ────────────────────────────────────────────────────────────
 gateway = true              # full-tunnel: весь трафик LAN в туннель (+ NAT в S99qeli)
@@ -130,11 +133,17 @@ file  = /opt/var/log/qeli-client.log
 ```
 
 **H-1 / `bind_static` (важно с 0.7.1):** по умолчанию клиент привязывает сессию к
-запиненному статическому ключу сервера. Два рабочих варианта для роутера:
+запиненному статическому ключу сервера. Флаг **должен совпадать на клиенте и сервере**
+(у обоих дефолт `true`): при рассинхроне KDF расходится (разные HKDF-соли) и коннект
+падает с `Connection error: decryption failed` сразу после `reading server auth proof`.
+Два рабочих варианта для роутера:
 - **Безопасно (рекомендуется):** впиши реальный `key` (из `qeli show-identity`) и
   оставь `bind_static` по умолчанию (on). TOFU-пин сохраняется в `QELI_KNOWN_HOSTS`
   (в `S99qeli` это `/opt/etc/qeli/known_hosts` — переживает ребут, в отличие от `/var`).
 - **TOFU (проще):** `key` = нули и `bind_static = false` — доверие при первом коннекте.
+- **`mode = reality-tls`:** реальный `key` + `reality_sid` обязательны (TOFU-нули не
+  работают), поэтому `bind_static` тут **обязан быть `true`** — просто убери строку
+  `bind_static = false`. Оставленный `false` = гарантированный `decryption failed`.
 
 ---
 
@@ -193,6 +202,13 @@ curl -s https://ifconfig.me ; echo
 
 ---
 
+## OpkgTun — интерфейс в вебморде (KeeneticOS 5.0+)
+
+Опциональный режим: tun отдаётся `ndm` как нативный `OpkgTun`-интерфейс, виден в вебморде
+и доступен в «Приоритетах подключений». Это отдельный аддон со своими оговорками (владение
+L3, статический IP, ручная регистрация) — вся настройка и разбор в
+[`release/keenetic/opkgtun/README.md`](../../release/keenetic/opkgtun/README.md).
+
 ## Диагностика
 
 | Симптом | Причина / что делать |
@@ -200,12 +216,14 @@ curl -s https://ifconfig.me ; echo
 | `нет /dev/net/tun` при старте | Включить компонент VPN в KeeneticOS (предусловия) |
 | `ip: ... tuntap` не работает | `opkg install ip-full` (busybox-`ip` урезан) |
 | Нет `Auth OK`, `SERVER KEY MISMATCH` | Неверный `key` — сверь с `qeli show-identity` на сервере |
+| `decryption failed` сразу после `reading server auth proof` | `bind_static` не совпадает с сервером (у обоих дефолт `true`): убери `bind_static = false` на клиенте (для reality-tls он обязан быть `true`) ИЛИ выстави одинаково на сервере. Также проверь, что версии qeli на роутере и сервере совпадают (`qeli --version`) |
 | Нет `Auth OK`, ошибка про `bind_static`/all-zero TOFU | H-1 (0.7.1) ВКЛ по умолчанию: впиши реальный `key` ИЛИ поставь `bind_static = false` для TOFU |
 | Нет `Auth OK`, `auth failed` | Неверные `user`/`pass`, либо `mode`/`sni` не совпадают с профилем сервера |
 | `kill-switch: iptables is not installed` | Убедись, что `iptables` в PATH (на Keenetic он есть); иначе `kill_switch = false` |
 | LAN без интернета, роутер с интернетом | Проверь `ip_forward`, `MASQUERADE`, правильное имя `LAN_IF` в `S99qeli` |
 | После ребута сервер видит «новое устройство» / повторный TOFU | `QELI_DEVICE_ID_FILE` и `QELI_KNOWN_HOSTS` должны быть на `/opt` (в `S99qeli` уже так; `/var` — tmpfs) |
 | Очень медленно (mipsel) | Потолок CPU без AES-NI; ставь `mode = obfs`/`plain`, не `reality-tls` |
+| OpkgTun-режим (вебморда) | Отдельная диагностика — [`release/keenetic/opkgtun/README.md`](../../release/keenetic/opkgtun/README.md) |
 | Туннель рвётся | Авто-reconnect включён; смотри `/opt/var/log/qeli-client.log` |
 
 ---

--- a/docs/ru/KEENETIC-PORT.md
+++ b/docs/ru/KEENETIC-PORT.md
@@ -190,8 +190,15 @@ iptables -A FORWARD -i vpn0 -o br0 -m state --state RELATED,ESTABLISHED -j ACCEP
 - **Перф на MIPS** — потолок десятки Мбит (софт-крипто). Для канала до ~50–100 Мбит
   ок, для гигабита нет.
 - **Интеграция с NAT/firewall KeeneticOS** — непредсказуема, зависит от модели/прошивки.
-- **Нет нативной интеграции в веб-морду KeeneticOS** — это сторонний Entware-демон
-  (SSH/init-скрипт). Полноценный KeeneticOS-компонент требует SDK Keenetic — вне реализма.
+- **Интеграция в веб-морду** — с KeeneticOS 5.0 tun можно отдать ndm как нативный
+  `OpkgTun`-интерфейс: он виден в вебморде и доступен в «Приоритетах подключений» /
+  статических маршрутах (`dev=opkgtun0` + регистрация через `ndmc` из wan.d-хука — см.
+  `release/keenetic/`). qeli использует kernel-tun («system»-режим); по данным сообщества на OpkgTun
+  официально разрешён ТОЛЬКО gvisor (userspace-стек), поэтому поедет ли kernel-tun через
+  OpkgTun на 5.x — НЕ подтверждено (проверка на устройстве). Перевод qeli на gvisor — не
+  флаг, а крупная переработка (Rust: smoltcp/собственный netstack + проприетарный контракт
+  Keenetic OpkgTun-gvisor, который сейчас реализуют Go-клиенты вроде amneziawg-go). На KeeneticOS ≤4.x нативной интеграции нет (только
+  SSH/init + скриптовый PBR через `ip rule`/`ipset`).
 
 ## 9. Чек-лист
 

--- a/qeli/src/client/mod.rs
+++ b/qeli/src/client/mod.rs
@@ -1187,8 +1187,12 @@ where
     unsafe {
         libc::close(tun_fd);
     }
-    TunInterface::delete(&tun_name).ok();
-    route::cleanup_routes(&tun_name, &server_addr, &config.routing.exclude).ok();
+    // Attach mode: the interface + routes belong to an external owner — leave them
+    // (we only borrowed the fd). Otherwise remove the device + routes we created.
+    if !config.tun.attach_existing {
+        TunInterface::delete(&tun_name).ok();
+        route::cleanup_routes(&tun_name, &server_addr, &config.routing.exclude).ok();
+    }
     log::info!("Client disconnected");
     Ok(())
 }
@@ -1830,8 +1834,16 @@ fn log_server_push(
         client_ip,
         prefix,
         server_ip,
-        if pushed_mtu > 0 { pushed_mtu.to_string() } else { "-".to_string() },
-        if dns_ip.is_empty() { "-".to_string() } else { format!("{}:{}", dns_ip, dns_port) },
+        if pushed_mtu > 0 {
+            pushed_mtu.to_string()
+        } else {
+            "-".to_string()
+        },
+        if dns_ip.is_empty() {
+            "-".to_string()
+        } else {
+            format!("{}:{}", dns_ip, dns_port)
+        },
         n_routes,
         if pushed_obf.is_some() { "yes" } else { "-" },
         max_streams,
@@ -1847,7 +1859,10 @@ fn log_server_push(
             pushed_mtu, config.tun.mtu, eff
         );
     } else {
-        log::info!("server push: mtu {} APPLIED (client mtu = 0/auto)", pushed_mtu);
+        log::info!(
+            "server push: mtu {} APPLIED (client mtu = 0/auto)",
+            pushed_mtu
+        );
     }
 
     // DNS — applied only when this client manages the resolver (dns = tunnel).
@@ -1865,7 +1880,9 @@ fn log_server_push(
     } else {
         log::info!(
             "server push: DNS {}:{} APPLIED (client dns = {})",
-            dns_ip, dns_port, config.dns.mode
+            dns_ip,
+            dns_port,
+            config.dns.mode
         );
     }
 
@@ -1894,7 +1911,8 @@ fn log_server_push(
     if max_streams > 1 {
         log::info!(
             "server push: multipath max_streams={} adaptive={}",
-            max_streams, adaptive
+            max_streams,
+            adaptive
         );
     }
 }
@@ -2034,42 +2052,81 @@ fn setup_tunnel(
 ) -> anyhow::Result<TunnelSetup> {
     let is_tap = is_tap_mode(&config.tun.device_type);
     let if_name = tap_interface_name(&config.tun.name, &config.tun.device_type);
+    let attach = config.tun.attach_existing;
+    let dev_label = if is_tap { "TAP" } else { "TUN" };
     log::info!("TUN MTU: {}", mtu);
 
-    // Refuse to take over an interface that already exists — it may belong to another
-    // VPN/app, and clobbering it (delete + recreate) is destructive. Our tun is
-    // non-persistent (it vanishes when the process exits), so an existing name is almost
-    // always a different app or a still-running qeli, NOT our own leftover. The operator
-    // should pick a distinct name via `dev=` in [qeli] instead.
-    if std::path::Path::new(&format!("/sys/class/net/{}", if_name)).exists() {
-        anyhow::bail!(
-            "interface '{}' already exists (another app, or a running qeli?) — refusing to \
-             take it over. Set 'dev=<name>' in [qeli] to use a different interface name.",
-            if_name
-        );
+    let exists = std::path::Path::new(&format!("/sys/class/net/{}", if_name)).exists();
+    if attach {
+        // Attach to a PRE-EXISTING, externally-owned interface; we only open it for
+        // packet IO. If it's not there yet, error out and let the reconnect loop retry
+        // until the owner creates it.
+        if !exists {
+            anyhow::bail!(
+                "dev_attach is set but interface '{}' does not exist yet — waiting for its \
+                 owner to create it (the reconnect loop will retry).",
+                if_name
+            );
+        }
+        log::info!("Attaching to existing {} interface {}", dev_label, if_name);
+    } else {
+        // Refuse to take over an interface that already exists — it may belong to another
+        // VPN/app, and clobbering it (delete + recreate) is destructive. Our tun is
+        // non-persistent (it vanishes when the process exits), so an existing name is almost
+        // always a different app or a still-running qeli, NOT our own leftover. The operator
+        // should pick a distinct name via `dev=` in [qeli] instead (or `dev_attach=true` to
+        // intentionally attach to an externally-owned interface).
+        if exists {
+            anyhow::bail!(
+                "interface '{}' already exists (another app, or a running qeli?) — refusing to \
+                 take it over. Set 'dev=<name>' in [qeli] to use a different interface name \
+                 (or 'dev_attach=true' to attach to an externally-owned interface).",
+                if_name
+            );
+        }
+        log::info!("Creating {} interface {}", dev_label, if_name);
     }
+
+    // `TUNSETIFF` creates the device when absent and ATTACHES to it when it already
+    // exists — so the same call serves both the create and the (attach) path.
     let tun_res = if is_tap {
-        log::info!("Creating TAP interface {}", if_name);
         TunInterface::create_tap(&if_name, mtu)
     } else {
-        log::info!("Creating TUN interface {}", if_name);
         TunInterface::create(&if_name, mtu)
     };
     let tun = tun_res.map_err(|e| {
         anyhow::anyhow!(
-            "failed to create {} interface '{}': {} — is it already in use by another app? \
+            "failed to {} {} interface '{}': {} — is it already in use by another app? \
              Set 'dev=<name>' in [qeli] to use a different interface name.",
-            if is_tap { "TAP" } else { "TUN" },
+            if attach { "attach to" } else { "create" },
+            dev_label,
             if_name,
             e
         )
     })?;
-    TunInterface::set_address(&if_name, client_ip, netmask)?;
-    TunInterface::set_up(&if_name, mtu)?;
+    if attach {
+        // The interface owner sets L3 (address + link up) — some managers only route
+        // through an interface they configured themselves, so if qeli sets the address
+        // the owner never treats it as connected. We only pump packets, and export the
+        // server-assigned IP via `QELI_TUNIP_FILE` so the owner can apply it.
+        if let Ok(path) = std::env::var("QELI_TUNIP_FILE") {
+            if !path.is_empty() {
+                if let Err(e) = crate::util::write_atomic(&path, client_ip.as_bytes()) {
+                    log::warn!("could not write tun IP to {}: {}", path, e);
+                }
+            }
+        }
+        log::info!(
+            "Attached {}; L3 (address {}) left to its owner",
+            if_name,
+            client_ip
+        );
+    } else {
+        TunInterface::set_address(&if_name, client_ip, netmask)?;
+        TunInterface::set_up(&if_name, mtu)?;
+        log::info!("{} {} is up (IP: {})", dev_label, if_name, client_ip);
+    }
     tun.set_nonblocking()?;
-
-    let dev_label = if is_tap { "TAP" } else { "TUN" };
-    log::info!("{} {} is up (IP: {})", dev_label, if_name, client_ip);
 
     let raw_reader = unsafe { libc::dup(tun.as_raw_fd()) };
     let raw_writer = unsafe { libc::dup(tun.as_raw_fd()) };
@@ -2087,7 +2144,10 @@ fn setup_tunnel(
         return Err(anyhow::anyhow!("failed to dup TUN fd"));
     }
 
-    route::setup_routes(&config.routing, server_ip, &if_name, &config.server.address)?;
+    // Attach mode: routing belongs to the interface owner — don't install our own.
+    if !attach {
+        route::setup_routes(&config.routing, server_ip, &if_name, &config.server.address)?;
+    }
     // On a full-tunnel host with dns=off, all traffic is routed through the tunnel but the
     // system resolver is left untouched — on a normal host (unlike a router with its own
     // local resolver) that can leak DNS to the physical network's resolver. Make it visible.
@@ -2938,8 +2998,11 @@ async fn connect_and_run_udp(
     unsafe {
         libc::close(tun_fd);
     }
-    TunInterface::delete(&tun_name).ok();
-    route::cleanup_routes(&tun_name, &server_addr, &config.routing.exclude).ok();
+    // Attach mode: the interface + routes belong to an external owner — leave them.
+    if !config.tun.attach_existing {
+        TunInterface::delete(&tun_name).ok();
+        route::cleanup_routes(&tun_name, &server_addr, &config.routing.exclude).ok();
+    }
     log::info!("UDP client disconnected");
     Ok(())
 }

--- a/qeli/src/config/client.rs
+++ b/qeli/src/config/client.rs
@@ -113,6 +113,16 @@ pub struct ClientTunConfig {
     pub mtu_probe: bool,
     #[serde(default = "default_device_type")]
     pub device_type: String,
+    /// Attach to a PRE-EXISTING interface (`name`/`dev`) that an external manager
+    /// created and owns, instead of creating our own. qeli only opens it for packet IO:
+    /// it does NOT create it, set its address, bring the link up, install routes, or
+    /// delete it on teardown — L3 and routing belong to the owner (some managers only
+    /// route through an interface they configured themselves). The server-assigned
+    /// tunnel IP is written to `$QELI_TUNIP_FILE` (when set) so the owner can apply it.
+    /// If the interface is absent at connect time, qeli errors and the reconnect loop
+    /// retries. Default false (create and own the interface).
+    #[serde(default = "default_false")]
+    pub attach_existing: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -452,6 +462,9 @@ impl ClientConfig {
         if let Some(d) = q.get("dev").filter(|s| !s.is_empty()) {
             cfg.tun.name = d.to_string();
         }
+        // Attach to an existing, externally-owned interface named `dev` instead of
+        // creating our own. See ClientTunConfig::attach_existing.
+        cfg.tun.attach_existing = q.bool_or("dev_attach", cfg.tun.attach_existing);
 
         // TUN MTU. Omitted or 0 = auto (adopt the server-pushed MTU); a positive
         // value is an explicit override.
@@ -707,6 +720,10 @@ impl ClientConfig {
         if self.tun.name != "vpn0" {
             q.set("dev", &self.tun.name);
         }
+        // Emit only when enabled (default false = own the interface).
+        if self.tun.attach_existing {
+            q.set("dev_attach", "true");
+        }
         // Emit mtu only when explicitly overridden (>0). 0/absent = auto = adopt
         // the server-pushed MTU.
         if self.tun.mtu > 0 {
@@ -844,6 +861,31 @@ sni    = www.cloudflare.com
         assert_eq!(c.tun.name, "vpn7");
         let back = ClientConfig::from_ini(&IniDoc::parse(&c.to_ini_string()).unwrap()).unwrap();
         assert_eq!(back.tun.name, "vpn7");
+    }
+
+    #[test]
+    fn dev_attach_parses_and_round_trips() {
+        // Absent -> default false (own the interface).
+        let def = ClientConfig::from_ini(
+            &IniDoc::parse("[qeli]\nserver = h:443\nuser = u\npass = p\n").unwrap(),
+        )
+        .unwrap();
+        assert!(!def.tun.attach_existing);
+        // The secure default (false) is not emitted back.
+        assert!(!def.to_ini_string().contains("dev_attach"));
+        // Explicit `dev_attach = true` parses and survives a round-trip.
+        let c = ClientConfig::from_ini(
+            &IniDoc::parse(
+                "[qeli]\nserver = h:443\nuser = u\npass = p\ndev = ext0\ndev_attach = true\n",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(c.tun.attach_existing);
+        assert_eq!(c.tun.name, "ext0");
+        let back = ClientConfig::from_ini(&IniDoc::parse(&c.to_ini_string()).unwrap()).unwrap();
+        assert!(back.tun.attach_existing);
+        assert_eq!(back.tun.name, "ext0");
     }
 
     #[test]

--- a/release/keenetic/opkgtun/010-qeli.sh
+++ b/release/keenetic/opkgtun/010-qeli.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# /opt/etc/ndm/wan.d/010-qeli.sh — регистрация qeli-tun как нативного OpkgTun-интерфейса
+# ndm (KeeneticOS 5.0+), чтобы он был виден в вебморде и доступен в «Приоритетах
+# подключений» / статических маршрутах.
+#
+# Вызывается САМИМ ndm на сетевых событиях → ndmc работает в правильном контексте.
+# (Из init.d / non-login shell ndmc падает с `ndmc: system failed [0xcffd0060]`,
+# поэтому регистрация живёт здесь, а не в S99qeli.)
+#
+# ТРЕБУЕТ в client.conf: dev = opkgtun0 И dev_attach = true — qeli ПРИЦЕПЛЯЕТСЯ к
+# созданному ndm устройству и НЕ трогает L3. Всё остальное (адрес/линк/маршруты) держит
+# ndm — иначе интерфейс залипает в `connected: no` и ndm не маршрутит через него.
+#
+# МОДЕЛЬ (KeenOS 5.0), критично соблюсти порядок и владение:
+#   (1) ndm создаёт интерфейс OpkgTun0 → появляется kernel-device opkgtun0;
+#   (2) qeli цепляется к нему (dev_attach), при auth пишет выданный сервером IP в TUNIP;
+#   (3) ndm ставит этот IP как /32 + global + up → connected: yes → маршрутизация работает.
+# Если L3 поставит qeli, а не ndm — ndm застрянет в `link: pending / connected: no`
+# (проверено на устройстве). Если qeli сам СОЗДАСТ opkgtun0 — ndm даст `system failed
+# [0xcffd00a9]`. Хук идемпотентен; ndm дёргает wan.d на событиях → регистрация докручивается.
+
+STATE=/opt/var/run/qeli.opkgtun          # маркер: S99qeli пишет сюда имя tun в OpkgTun-режиме
+TUNIP=/opt/var/run/qeli.tunip            # qeli пишет сюда выданный сервером IP (attach-режим)
+LOG=/opt/var/log/qeli-client.log
+export PATH=/opt/sbin:/opt/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ -f "$STATE" ] || exit 0                 # OpkgTun-режим в S99qeli выключен — выходим тихо
+IF="$(cat "$STATE" 2>/dev/null)"          # имя kernel-tun (напр. opkgtun0)
+case "$IF" in opkgtun[0-9]*) ;; *) exit 0 ;; esac
+NDM_IF="OpkgTun${IF#opkgtun}"             # opkgtun0 -> OpkgTun0 (ndm капитализирует)
+
+# Разведка формата событий (раскомментируй ОДИН раз на устройстве, потом верни назад):
+# { echo "--- wan.d/010-qeli $(date) ---"; env; } >> "$LOG" 2>&1
+
+# IP, который qeli выдал сервер (нужен и для guard'а, и для регистрации ниже).
+WANT_IP="$(grep -oE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' "$TUNIP" 2>/dev/null | head -n1)"
+
+# Уже поднят, подключён и с нужным адресом? Тихо выходим — работы нет (идемпотентность +
+# защита от петли событий ndm: наш `... up`/`ip route` ниже сами генерят события wan.d).
+CUR="$(ndmc -c "show interface $NDM_IF" 2>/dev/null)"
+if echo "$CUR" | grep -q "connected: yes" \
+   && { [ -z "$WANT_IP" ] || echo "$CUR" | grep -q "address: $WANT_IP"; }; then
+  exit 0
+fi
+
+# (1) Убеждаемся, что интерфейс есть в ndm (заводит kernel-device opkgtun0 для attach'а qeli).
+# Создание идемпотентно; если интерфейс УЖЕ существует (персистентный конфиг / ndm его
+# пере-инициализирует после реконнекта qeli), ndmc может вернуть не-ноль — это НЕ ошибка,
+# поэтому фатально считаем только реальное отсутствие интерфейса (show тоже не находит).
+ndmc -c "interface $NDM_IF" >/dev/null 2>&1
+if ! ndmc -c "show interface $NDM_IF" >/dev/null 2>&1; then
+  echo "wan.d/010-qeli: $NDM_IF недоступен в ndm (KeeneticOS <5.0? не тот контекст?)" >> "$LOG"
+  exit 0
+fi
+
+# (2) Ждём, пока qeli приатачится и запишет выданный сервером IPv4 в TUNIP-файл.
+# В attach-режиме qeli НЕ ставит адрес сам (иначе ndm застрянет в connected:no), поэтому
+# IP берём из файла, а не с интерфейса. Таймаут короткий, чтобы не блокировать обработчик
+# событий ndm — если qeli ещё в backoff, регистрацию докрутит следующий вызов хука.
+i=0; IP="$WANT_IP"
+while [ -z "$IP" ] && [ $i -lt 10 ]; do
+  IP="$(grep -oE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' "$TUNIP" 2>/dev/null | head -n1)"
+  [ -n "$IP" ] && break
+  # запасной источник: вытащить из лога qeli ("Auth OK, assigned IP: 10.9.0.3")
+  IP="$(sed -n 's/.*assigned IP: \([0-9.]*\).*/\1/p' "$LOG" 2>/dev/null | tail -n1)"
+  [ -n "$IP" ] && break
+  i=$((i + 1)); sleep 1
+done
+[ -n "$IP" ] || { echo "wan.d/010-qeli: $NDM_IF создан, ждём attach qeli (нет IP в $TUNIP)" >> "$LOG"; exit 0; }
+
+MTU=1400   # MTU туннеля (в логе qeli: "TUN MTU: 1400"). Поменяй, если сервер пушит другой.
+
+# (3) Ставим L3 через ndm — ndm ДОЛЖЕН владеть адресом/линком, иначе connected:no и нет
+# маршрутизации. Команды декларативные → повторный вызов с теми же значениями безопасен.
+# `ip global auto` = «для выхода в интернет» (без него маршруты через интерфейс не идут).
+# `security-level public` = ndm сам делает masquerade/firewall (свой NAT не нужен).
+# `ip route default $NDM_IF` даёт policy-routing через tun; конкретные маршруты — из UI/ndmc.
+ndmc -c "interface $NDM_IF description qeli-VPN"
+ndmc -c "interface $NDM_IF ip global auto"
+ndmc -c "interface $NDM_IF ip address $IP 255.255.255.255"
+ndmc -c "interface $NDM_IF ip mtu $MTU"
+ndmc -c "interface $NDM_IF ip tcp adjust-mss pmtu"
+ndmc -c "interface $NDM_IF security-level public"
+ndmc -c "interface $NDM_IF up"
+ndmc -c "ip route default $NDM_IF"
+ndmc -c "system configuration save"
+echo "wan.d/010-qeli: $NDM_IF up ($IP/32, mtu $MTU) — L3 держит ndm" >> "$LOG"

--- a/release/keenetic/opkgtun/README.md
+++ b/release/keenetic/opkgtun/README.md
@@ -1,0 +1,130 @@
+# qeli на Keenetic через OpkgTun (интерфейс в вебморде)
+
+Опциональный режим для **KeeneticOS 5.0+**: qeli-tun отдаётся `ndm` как нативный
+интерфейс `OpkgTunN`, который виден в вебморде и доступен в **«Приоритетах подключений»**
+и статических маршрутах. Тогда per-device / selective роутинг настраивается мышкой в UI,
+без самодельного NAT из `S99qeli`.
+
+Это **аддон**, изолированный в этой папке. Базовый gateway-режим (надёжный, без зависимости
+от ndm) — в `release/keenetic/`. Если UI-роутинг не нужен — используй его, он проще и
+переживает ребут без нюансов ниже.
+
+> ⚠️ **Честно о зрелости.** OpkgTun-интеграция рабочая, но **хрупкая и полу-ручная**:
+> - авто-регистрация через wan.d-хук на раннем бусте **ненадёжна** (ndmc в этом контексте
+>   часто не отвечает) — рабочая регистрация делается вручную из ssh-логина;
+> - переживание ребута требует **статического IP на сервере** (иначе адрес «уплывает» и
+>   сохранённый в ndm конфиг устаревает);
+> - нативного тумблера вкл/выкл в «Других подключениях» у OpkgTun нет (фича-реквест Keenetic).
+>
+> Разумно на ARM-моделях; на mipsel — только лёгкие режимы маскировки.
+
+## Модель владения (ключевое, проверено на устройстве)
+
+На 5.0 устройство `opkgtun0` **создаёт и держит САМ `ndm`**, а приложение к нему
+**прицепляется**, и **L3 (адрес + линк) тоже ставит ndm, а не приложение**. Две ловушки:
+
+- qeli сам создаёт `opkgtun0` → `ndm` не заводит интерфейс:
+  `Opkg::Interface::Tun error: "OpkgTun0": system failed [0xcffd00a9]`,
+  а qeli — `interface 'opkgtun0' already exists … refusing to take it over`.
+- qeli сам ставит адрес/поднимает линк → `ndm` навсегда залипает в
+  `link: pending / connected: no` и **не маршрутизирует** через интерфейс. Только когда
+  адрес ставит ndm (`ip address … /32` + `up`), интерфейс переходит в `connected: yes`.
+
+Поэтому qeli в **attach-режиме** (`dev_attach = true`): открывает существующее
+ndm-устройство **только для перекачки пакетов** — не создаёт его, не ставит адрес, не
+поднимает линк, не трогает маршруты, не удаляет при выходе. Выданный сервером IP qeli пишет
+в `$QELI_TUNIP_FILE`, а адрес/линк/маршруты держит `ndm` (через хук).
+
+> ℹ️ **Про «gvisor only».** Форумные упоминания, что «на OpkgTun разрешён только gvisor»,
+> относятся к ВНУТРЕННИМ tun-stack режимам Clash/sing-box (`system`/`gvisor`/`mixed` — опция
+> самого приложения), а НЕ к ndm. Обычный kernel-tun через OpkgTun работает (так живёт,
+> например, AmneziaWG-Go). Затык `0xcffd00a9` был не в gvisor, а в порядке/владении устройством.
+
+## Файлы в этой папке
+
+- `010-qeli.sh` — wan.d-хук: создаёт `OpkgTun0`, ждёт IP от qeli, ставит L3 через ndmc.
+- `S99qeli` — init-скрипт с преднастроенным `OPKGTUN=opkgtun0` (в OpkgTun-режиме свой NAT
+  выключен; сигналит хуку и экспортит `QELI_TUNIP_FILE`).
+- `client.conf.example` — пример конфига (`dev = opkgtun0`, `dev_attach = true`, `gateway = false`).
+
+## Установка
+
+1. Клиент (общий бинарь) и базовый деплой — по `release/keenetic/README.md`.
+2. Скопируй OpkgTun-файлы:
+   ```sh
+   cp opkgtun/S99qeli            /opt/etc/init.d/S99qeli
+   mkdir -p /opt/etc/ndm/wan.d
+   cp opkgtun/010-qeli.sh        /opt/etc/ndm/wan.d/010-qeli.sh
+   chmod +x /opt/etc/init.d/S99qeli /opt/etc/ndm/wan.d/010-qeli.sh
+   ```
+3. В `/opt/etc/qeli/client.conf` задай `dev = opkgtun0`, `dev_attach = true`, `gateway = false`
+   (см. `opkgtun/client.conf.example`).
+4. **Пин статического IP на сервере** для этого пользователя (обязательно для ребута) — см. ниже.
+5. `/opt/etc/init.d/S99qeli start`.
+
+## Статический IP (обязательно для переживания ребута)
+
+Сервер по умолчанию выдаёт IP из пула, и после ребута он может смениться → сохранённый в ndm
+адрес устареет → маршрутизация сломается. Зафиксируй IP на сервере (сервер это умеет):
+
+- **веб-панель**: пользователь → поле статического IP;
+- **CLI (новый юзер)**: `qeli add-client <user> --static-ip 10.9.0.2 …`;
+- **конфиг сервера**: `static_ip = "10.9.0.2"` в `[user:<name>]`, либо
+  `pool.reservation.<user> = "10.9.0.2"` в профиле (см. `docs/eng/CONFIG.md`).
+
+Применяется на следующем коннекте (user db читается на auth в реальном времени).
+
+## Регистрация вручную (надёжный путь)
+
+wan.d-хук на бусте часто не может выполнить ndmc. Рабочий способ — **из ssh-ЛОГИНА**
+(не из `exec sh` — иначе `0xcffd0060`), порядок тот же, что в хуке:
+
+```sh
+ndmc -c "interface OpkgTun0"                 # 1. ndm создаёт kernel-device opkgtun0
+/opt/etc/init.d/S99qeli start                # 2. qeli цепляется, пишет IP в файл
+IP=$(cat /opt/var/run/qeli.tunip)            # 3. берём IP и отдаём L3 целиком ndm (адрес /32!)
+ndmc -c "interface OpkgTun0 ip global auto"
+ndmc -c "interface OpkgTun0 ip address $IP 255.255.255.255"
+ndmc -c "interface OpkgTun0 ip mtu 1400"
+ndmc -c "interface OpkgTun0 ip tcp adjust-mss pmtu"
+ndmc -c "interface OpkgTun0 security-level public"
+ndmc -c "interface OpkgTun0 up"
+ndmc -c "ip route default OpkgTun0"
+ndmc -c "system configuration save"
+ndmc -c "show interface OpkgTun0" | grep -E "connected|global"   # ждём connected: yes, global: yes
+```
+Снять интерфейс: `ndmc -c "no interface OpkgTun0"`.
+
+## Маршрутизация
+
+- **Весь трафик устройства → VPN**: «Интернет → Приоритеты подключений» → профиль с
+  `OpkgTun0` выше WAN → привязать устройство. Работает для любых адресов/CDN, ndm сам NAT'ит.
+- **Точечный маршрут**: `ndmc -c "ip route <сеть> <маска> OpkgTun0"` + `system configuration save`.
+  UI-статик ненадёжен: маршрут ложится в table `main`, которую трафик клиента не смотрит
+  (сначала `from all lookup 4096`), плюс баг вебморды сбрасывает выбор интерфейса на дефолт.
+- Интерфейс обязан быть `connected: yes` и `global: yes` — иначе маршруты не активируются.
+- НЕ ставь `ip route default OpkgTun0` для роутера в целом — завернётся и соединение qeli с
+  сервером → петля. Заворачивай клиентов через Приоритеты.
+
+Проверка exit-IP туннеля (минуя роутинг/DNS): `curl --interface opkgtun0 -s https://api.ipify.org`.
+
+## Диагностика
+
+| Симптом | Причина / что делать |
+|---|---|
+| `system failed [0xcffd00a9]` + qeli `already exists` | Инверсия владения: поставь `dev_attach = true`, дай ndm создать интерфейс первым |
+| Маршрут не идёт; `show interface` = `connected: no` / `link: pending`, `global: no` | L3 должен держать ndm. Проверь `dev_attach = true`, что qeli пишет IP в `/opt/var/run/qeli.tunip`, и что адрес `/32` + `ip global` ставит ndm |
+| Хук: `OpkgTun0 недоступен` / `не принял` | ndmc в контексте wan.d (особенно на бусте) не отвечает — зарегистрируй вручную из ssh-логина |
+| После ребута маршрут отвалился, IP сменился | Нет статического IP → пин на сервере (см. выше) |
+| Файла `/opt/var/run/qeli.tunip` нет | `OPKGTUN=` пуст в S99qeli, либо старый бинарь без `dev_attach` |
+| Нет тумблера вкл/выкл в «Других подключениях» | Штатно не поддерживается (фича-реквест Keenetic); управляй через `ndmc interface OpkgTun0 up/down` + стоп qeli |
+
+## Удаление / откат на gateway
+
+```sh
+/opt/etc/init.d/S99qeli stop
+ndmc -c "no interface OpkgTun0"                 # из ssh-логина
+rm -f /opt/etc/ndm/wan.d/010-qeli.sh
+cp ../S99qeli /opt/etc/init.d/S99qeli           # базовый gateway-скрипт
+# в client.conf: dev = vpn0, gateway = true, убрать dev_attach
+```

--- a/release/keenetic/opkgtun/S99qeli
+++ b/release/keenetic/opkgtun/S99qeli
@@ -1,0 +1,100 @@
+#!/bin/sh
+# /opt/etc/init.d/S99qeli — запуск qeli-client на Keenetic (Entware).
+# ВАРИАНТ ДЛЯ OpkgTun (вебморда, KeeneticOS 5.0+): OPKGTUN=opkgtun0 задан ниже.
+# Для обычного gateway-режима бери базовый ../S99qeli (или очисти OPKGTUN=).
+# Управление: /opt/etc/init.d/S99qeli {start|stop|restart|status}
+# ⚠️ ШАБЛОН: проверь LAN_IF под свою модель/прошивку (`ip a`). Детали — README.md рядом.
+
+BIN=/opt/bin/qeli-client
+CONF=/opt/etc/qeli/client.conf
+PIDFILE=/opt/var/run/qeli-client.pid
+LOG=/opt/var/log/qeli-client.log
+TUN=vpn0            # имя tun (должно совпадать с dev= в конфиге; дефолт vpn0)
+LAN_IF=br0          # LAN-бридж роутера (проверь `ip a` — бывает br0/bridge0)
+GATEWAY=yes         # yes = самодельный NAT/forward (KeeneticOS ≤4.x или режим без OpkgTun)
+
+# OpkgTun (KeeneticOS 5.0+): tun виден в вебморде и доступен в «Приоритетах подключений».
+# Задай имя kernel-tun (напр. opkgtun0) И поставь в client.conf dev=opkgtun0 + dev_attach=true
+# (на 5.0 opkgtun0 создаёт САМ ndm, qeli к нему прицепляется; без dev_attach ndm даёт
+# `system failed [0xcffd00a9]`). Если задан — самодельный NAT/GATEWAY отключается:
+# NAT/firewall/маршруты берёт на себя ndm, а регистрацию интерфейса делает хук
+# /opt/etc/ndm/wan.d/010-qeli.sh (ndmc из init.d даёт 0xcffd0060).
+OPKGTUN=opkgtun0    # пусто = выкл; opkgtun0 = включить нативный OpkgTun
+OPKGTUN_STATE=/opt/var/run/qeli.opkgtun   # маркер-файл для wan.d-хука (имя интерфейса)
+OPKGTUN_TUNIP=/opt/var/run/qeli.tunip     # qeli пишет сюда выданный сервером IP (для хука)
+[ -n "$OPKGTUN" ] && TUN="$OPKGTUN"       # в OpkgTun-режиме tun = $OPKGTUN
+
+# Персистентное состояние клиента на /opt (на роутере /var = tmpfs, теряется при ребуте).
+#  * device-id: иначе сервер каждый раз видит «новое устройство» и тратит слот сессии.
+#  * known_hosts: TOFU-пин статического ключа сервера (0.7.x). Без персистентности
+#    каждый ребут = повторный TOFU → окно для MITM на первом коннекте. Не нужно, если
+#    в конфиге задан реальный пиннингованный `key`.
+export QELI_DEVICE_ID_FILE=/opt/etc/qeli/device-id
+export QELI_KNOWN_HOSTS=/opt/etc/qeli/known_hosts
+# OpkgTun (dev_attach=true): qeli не трогает L3, а пишет выданный сервером IP сюда —
+# wan.d-хук читает файл и ставит адрес на OpkgTun0 через ndmc (L3 держит ndm).
+[ -n "$OPKGTUN" ] && export QELI_TUNIP_FILE="$OPKGTUN_TUNIP"
+export PATH=/opt/sbin:/opt/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+nat_up() {
+  [ -n "$OPKGTUN" ] && return 0     # OpkgTun-режим: NAT/firewall делает ndm
+  [ "$GATEWAY" = yes ] || return 0
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+  iptables -t nat -C POSTROUTING -o "$TUN" -j MASQUERADE 2>/dev/null || \
+    iptables -t nat -A POSTROUTING -o "$TUN" -j MASQUERADE
+  iptables -C FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT
+  iptables -C FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT
+}
+
+nat_down() {
+  [ -n "$OPKGTUN" ] && return 0     # OpkgTun-режим: NAT/firewall делает ndm
+  [ "$GATEWAY" = yes ] || return 0
+  iptables -t nat -D POSTROUTING -o "$TUN" -j MASQUERADE 2>/dev/null
+  iptables -D FORWARD -i "$LAN_IF" -o "$TUN" -j ACCEPT 2>/dev/null
+  iptables -D FORWARD -i "$TUN" -o "$LAN_IF" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null
+}
+
+is_running() { [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; }
+
+start() {
+  if is_running; then echo "qeli-client уже запущен (pid $(cat "$PIDFILE"))"; return 0; fi
+  if [ ! -e /dev/net/tun ]; then
+    echo "нет /dev/net/tun — включи компонент VPN в KeeneticOS"; exit 1
+  fi
+  mkdir -p /opt/var/run /opt/var/log /opt/etc/qeli
+  echo "qeli-client: старт"
+  "$BIN" --config "$CONF" >> "$LOG" 2>&1 &
+  echo $! > "$PIDFILE"
+  sleep 1
+  nat_up
+  if [ -n "$OPKGTUN" ]; then
+    echo "$OPKGTUN" > "$OPKGTUN_STATE"   # сигнал wan.d-хуку: регистрируй OpkgTun в ndm
+    echo "qeli-client: OpkgTun-режим ($OPKGTUN) — регистрация в ndm через wan.d-хук"
+  fi
+}
+
+stop() {
+  echo "qeli-client: стоп"
+  nat_down
+  if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" 2>/dev/null
+    rm -f "$PIDFILE"
+  fi
+  if [ -n "$OPKGTUN" ]; then
+    rm -f "$OPKGTUN_STATE" "$OPKGTUN_TUNIP"
+    # интерфейс из ndm снять вручную из ssh-логина: ndmc -c "no interface OpkgTun0"
+    # (tun сам исчезнет при завершении qeli — он non-persistent).
+  else
+    ip link del "$TUN" 2>/dev/null   # подчистить tun, если остался
+  fi
+}
+
+case "$1" in
+  start)   start ;;
+  stop)    stop ;;
+  restart) stop; sleep 1; start ;;
+  status)  is_running && echo "running (pid $(cat "$PIDFILE"))" || echo "stopped" ;;
+  *) echo "usage: $0 {start|stop|restart|status}"; exit 1 ;;
+esac

--- a/release/keenetic/opkgtun/client.conf.example
+++ b/release/keenetic/opkgtun/client.conf.example
@@ -1,0 +1,35 @@
+# qeli — клиентский конфиг для режима OpkgTun (интерфейс в вебморде Keenetic 5.0+).
+# Полное описание всех полей — в базовом ../client.conf.example. Здесь только то,
+# что специфично для OpkgTun. Комментарии — на ОТДЕЛЬНОЙ строке.
+
+[qeli]
+server = vpn.example.com:443
+proto = tcp
+user = router1
+pass = СМЕНИ_МЕНЯ
+# Реальный публичный ключ сервера ОБЯЗАТЕЛЕН (reality-tls и bind_static его требуют).
+# Возьми на сервере: qeli show-identity. Нулевой TOFU-ключ тут не годится.
+key = ВСТАВЬ_РЕАЛЬНЫЙ_КЛЮЧ
+# H-1: должен совпадать с сервером (у обоих дефолт true). Оставь по умолчанию (не выключай).
+
+# ── OpkgTun ──────────────────────────────────────────────────────────────────
+# Имя интерфейса, который создаёт и держит ndm; qeli к нему ПРИЦЕПЛЯЕТСЯ.
+dev = opkgtun0
+# ГЛАВНОЕ для OpkgTun: qeli не трогает L3 (адрес/линк/маршруты), только качает пакеты,
+# а выданный сервером IP пишет в $QELI_TUNIP_FILE — L3 ставит ndm (через wan.d-хук).
+# Без dev_attach ndm залипает в connected:no и не маршрутит через интерфейс.
+dev_attach = true
+# Маршрутами и NAT владеет ndm — свой шлюз/NAT НЕ включаем.
+gateway = false
+dns = off
+
+# Режим маскировки — должен совпадать с сервером. reality-tls разумен только на ARM
+# (двойной AEAD); на mipsel бери fake-tls/obfs/plain.
+mode = reality-tls
+sni = www.cloudflare.com
+# reality-tls требует и short_id (выдаёт сервер):
+# reality_sid = <hex>
+
+[logging]
+level = info
+file = /opt/var/log/qeli-client.log


### PR DESCRIPTION
Add a generic dev_attach client option: attach to a PRE-EXISTING, externally-owned interface instead of creating our own. qeli only pumps packets — it does not create the device, set L3, install routes, or delete it on teardown (the owner keeps L3/routing). The server-assigned tunnel IP is exported via $QELI_TUNIP_FILE so the owner can apply it. Usable outside Keenetic; default false.

Isolate all Keenetic web-UI (OpkgTun) material under release/keenetic/opkgtun/ (wan.d hook, OpkgTun-preconfigured S99qeli, config sample, README with setup/ownership model/static-IP requirement/caveats/diagnostics). The base release/keenetic/ stays clean gateway-mode.

docs(keenetic): document the reality-tls bind_static 'decryption failed' mismatch (must match the server) in KEENETIC-DEPLOY.md.