### PR TITLE
fix(panel): strip the XML prolog from the share QR SVG

### DIFF
--- a/qeli/src/web/api/share.rs
+++ b/qeli/src/web/api/share.rs
@@ -195,17 +195,25 @@ pub async fn share_link(
 
 /// Render a `qeli://` URI to a self-contained SVG QR code (no JS/CDN needed —
 /// the UI percent-encodes it into an `<img>` data URI; it is never injected as HTML).
-/// Returns `null` on the rare
-/// failure (e.g. payload exceeds QR capacity), so the UI can still show the URI.
+/// The returned markup STARTS at `<svg`: the panel's `svgDataUri` guard
+/// (`web/templates/users.html`) refuses anything that does not, because an `<img>` data
+/// URI is the only thing it will build. Returns `null` on the rare failure (e.g. payload
+/// exceeds QR capacity), so the UI can still show the URI.
 fn render_qr_svg(data: &str) -> Option<String> {
     use qrcode::{render::svg, QrCode};
     let code = QrCode::new(data.as_bytes()).ok()?;
-    Some(
-        code.render::<svg::Color>()
-            .min_dimensions(240, 240)
-            .quiet_zone(true)
-            .build(),
-    )
+    let markup = code
+        .render::<svg::Color>()
+        .min_dimensions(240, 240)
+        .quiet_zone(true)
+        .build();
+    // The renderer prefixes an XML prolog (`<?xml version="1.0" standalone="yes"?>`).
+    // The panel requires the payload to BEGIN with `<svg`, so that prolog turned every
+    // share into a blank <img> next to a perfectly good link — a 200 whose failure was
+    // invisible on both sides. Searched rather than stripped as a fixed literal so a
+    // future crate release rewording the prolog cannot silently reintroduce this.
+    let start = markup.find("<svg")?;
+    Some(markup[start..].to_string())
 }
 
 #[cfg(test)]
@@ -217,10 +225,17 @@ mod tests {
         let uri = "qeli://alice:pw@vpn.example.com:443?proto=tcp&mode=fake-tls\
                    &key=0a33d308295d5dc49bff020ca8a73e86b3f6797cbcc7d3aa440eee754729223a";
         let svg = render_qr_svg(uri).expect("QR should render for a normal share URI");
+        // STARTS with, not merely contains. `contains` passed happily while the renderer's
+        // XML prolog sat in front of `<svg`, which is exactly what the panel's data-URI
+        // guard rejects — so the old assertion could not see the bug it was there to catch.
         assert!(
-            svg.contains("<svg"),
-            "output should be SVG markup: {}",
+            svg.starts_with("<svg"),
+            "output must begin with SVG markup, or the panel renders a blank <img>: {}",
             &svg[..svg.len().min(80)]
+        );
+        assert!(
+            !svg.contains("<?xml"),
+            "an XML prolog must not survive into the panel payload"
         );
         assert!(svg.contains("</svg>"));
         assert!(


### PR DESCRIPTION
## Проблема

  В диалоге «Share connection (QR)» не отображается QR-код. Запрос `POST /api/share`
  при этом возвращает `200` с `ok: true`, ссылка `qeli://` формируется корректно —
  пустой остаётся только картинка.

  Причина — рассогласование контракта между сервером и панелью. SVG-рендерер крейта
  `qrcode` 0.14 предваряет вывод XML-прологом:

  ```
  <?xml version="1.0" standalone="yes"?><svg xmlns="http://www.w3.org/2000/svg" ...>
  ```

  А `svgDataUri` в `web/templates/users.html` требует, чтобы payload **начинался**
  с `<svg`, иначе возвращает пустую строку. В результате `<img :src="share.qr">`
  получает пустой `src`, и QR не рисуется.

  Юнит-тест это пропускал, потому что проверял `svg.contains("<svg")` — подстроку,
  а не начало строки. Пролог содержит `<svg` дальше по тексту, поэтому проверка
  проходила, физически не умея увидеть баг, ради которого написана.

  ## Решение

  `render_qr_svg` теперь возвращает разметку, начинающуюся ровно с `<svg`. Пролог
  отсекается **поиском** `find("<svg")`, а не срезом фиксированного литерала: смена
  формулировки пролога в будущем релизе крейта не вернёт баг тихо. Контракт зафиксирован
  в докблоке со ссылкой на потребителя.

  Тест ужесточён: `contains("<svg")` → `starts_with("<svg")` плюс проверка отсутствия
  `<?xml`. Это и есть суть исправления — старое утверждение не могло отловить регрессию.

  Затронут один файл, `qeli/src/web/api/share.rs`. Формат ответа API не меняется:
  поле `qr_svg` остаётся строкой либо `null`; единственный потребитель —
  `users.html:833`. Изменений в конфиге, схеме и UI нет.