### PR TITLE
fix(macos): restore DNS before utun close to skip the ~20 s configd stall

### DIFF
--- a/qeli-mac/QeliMac/Vpn/DnsJournal.cs
+++ b/qeli-mac/QeliMac/Vpn/DnsJournal.cs
@@ -251,7 +251,9 @@ internal sealed class DnsJournal
             return RecoveryResult.PreservedExternalChange;
         }
 
+        var sw = Stopwatch.StartNew();
         var restored = _write(state.Service, state.PreviousServers);
+        sw.Stop();
         if (!restored.Ok)
         {
             _log($"Failed to restore DNS on \"{state.Service}\": {restored.Error}; " +
@@ -264,7 +266,7 @@ internal sealed class DnsJournal
             return RecoveryResult.Failed;
         }
 
-        _log($"Restored DNS on \"{state.Service}\" to its pre-qeli value");
+        _log($"Restored DNS on \"{state.Service}\" to its pre-qeli value in {sw.ElapsedMilliseconds} ms");
         return RecoveryResult.Restored;
     }
 

--- a/qeli-mac/QeliMac/Vpn/VpnTunnel.cs
+++ b/qeli-mac/QeliMac/Vpn/VpnTunnel.cs
@@ -373,14 +373,12 @@ public sealed partial class VpnTunnel : VpnTunnelBase
         // leaves the machine as it was found. (C-18)
         try { RestoreIpForwarding(); }
         catch (Exception error) { failures.Add(error); }
-        var network = _net;
         try
         {
             // NetworkConfigurator deliberately throws when the physical service's DNS was
             // not restored. Keep the configurator referenced in that case so a second Stop
             // in this process can retry instead of forgetting the recovery action.
-            network?.Dispose();
-            if (ReferenceEquals(_net, network)) _net = null;
+            DisposeNetworkConfigurator();
         }
         catch (Exception error)
         {
@@ -471,12 +469,30 @@ public sealed partial class VpnTunnel : VpnTunnelBase
         // the old host route to the carrier can make the next handshake follow a vanished
         // gateway. Remove only that platform network transaction; keep the utun descriptor
         // and transparent-proxy classifier for fail-closed in-place reconfiguration.
+        DisposeNetworkConfigurator();
+    }
+
+    /// <summary>Idempotent configurator teardown: replays surviving undo entries
+    /// (successful ones are removed inside Dispose; failed ones stay registered for
+    /// the next pass). Every teardown path funnels through here so the dispose/null-out
+    /// dance exists exactly once.</summary>
+    private void DisposeNetworkConfigurator()
+    {
         var network = _net;
         network?.Dispose();
         if (ReferenceEquals(_net, network)) _net = null;
     }
 
-    protected override void BeforeTunDispose() => _perApp?.Stop();
+    protected override void BeforeTunDispose()
+    {
+        _perApp?.Stop();
+        try { RestoreIpForwarding(); }
+        catch { /* best effort here; CleanupPlatform retries and collects failures */ }
+        // Reset DNS and routes BEFORE closing the utun descriptor: XNU destroys the
+        // interface on close and configd then holds SCPreferences for ~20 s (with DHCP
+        // probes), blocking networksetup.
+        DisposeNetworkConfigurator();
+    }
 
     // Firewall kill-switch (full-tunnel only) via pf. Create/reserve the next utun before
     // raising PF, so the allowlist names only interfaces actually owned by this tunnel.


### PR DESCRIPTION
Disconnect disposed the NetworkConfigurator only after the utun descriptor was closed. XNU destroys the interface on close and configd then holds SCPreferences for ~20 s (with DHCP probes), blocking networksetup — so the DNS restore that teardown performs stalled past 20 s.

BeforeTunDispose now stops per-app control, retries the ip.forwarding sysctl restore, and disposes the configurator (DNS + routes) BEFORE the utun is closed. CleanupPlatform and the retained-tun rebuild funnel through the same idempotent DisposeNetworkConfigurator helper, so the dispose/ null-out dance exists exactly once and failed restores stay retryable. DnsJournal logs the restore duration in ms to make the recovery time visible.

Disclaimer: Assisted by AI